### PR TITLE
[Add] Initiate prometheus + grafana monitoring metrics report

### DIFF
--- a/cmd/u2u/launcher/launcher.go
+++ b/cmd/u2u/launcher/launcher.go
@@ -22,8 +22,8 @@ import (
 	evmetrics "github.com/ethereum/go-ethereum/metrics"
 
 	"github.com/unicornultrafoundation/go-u2u/cmd/u2u/launcher/metrics"
-	prometheus "github.com/unicornultrafoundation/go-u2u/cmd/u2u/launcher/monitoring"
 	"github.com/unicornultrafoundation/go-u2u/cmd/u2u/launcher/tracing"
+	"github.com/unicornultrafoundation/go-u2u/utils/prometheus"
 	"github.com/unicornultrafoundation/go-u2u/debug"
 	"github.com/unicornultrafoundation/go-u2u/evmcore"
 	"github.com/unicornultrafoundation/go-u2u/flags"

--- a/docker/README.MD
+++ b/docker/README.MD
@@ -1,0 +1,23 @@
+# Docker
+
+Contains the scripts to do u2u benchmarking (only for fakenet now) with Docker from [`docker/`] dir
+
+## Prometheus metrics collection
+  From [`docker/monitoring`] (./monitoring) dir
+  - `./local-prometheus-on.sh` start prometheus container in local
+  - `./prometheus-on.sh` start prometheus container collects metrics from running nodes (so run it after);
+  - `docker-compose.yaml` docker compose for starting multiple service configuration(Prometheus, Grafana, Cadvisor, NodeReporter) run with command `docker compose up`
+  From [`docker/monitoring/prometheus`] (./monitoring/prometheus) dir
+  - `prometheus.yml` configuration for prometheus monitoring defined enpoint
+  From [`docker/monitoring/grafana`] (./monitoring/grafana) dir
+  - `datasource.yml` data source for grafana analysising and storing
+  - see webUI at `http://localhost:9090`;
+  - stop: `./prometheus-off.sh`;
+
+See results at:
+
+ - client side: [tx latency](http://localhost:9090/graph?g0.range_input=5m&g0.expr=txstorm_tx_ttf&g0.tab=0)
+ - client side: [count of sent txs](http://localhost:9090/graph?g0.range_input=5m&g0.expr=txstorm_tx_count_sent&g0.tab=0)
+ - client side: [count of confirmed txs](http://localhost:9090/graph?g0.range_input=5m&g0.expr=txstorm_tx_count_got&g0.tab=0)
+ - node side: [tx time2finish](http://localhost:9090/graph?g0.range_input=5m&g0.expr=u2u_tx_ttf&g0.tab=0)
+ - node side: [data dir size](http://localhost:9090/graph?g0.range_input=5m&g0.expr=u2u_db_size&g0.tab=0)

--- a/docker/monitoring/docker-compose.yaml
+++ b/docker/monitoring/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     image: prom/prometheus:latest
     container_name: prometheus
     ports:
-      - 19090:19090
+      - 9090:9090
     volumes:
       - ./prometheus:/etc/prometheus
       - prometheus-data:/prometheus

--- a/docker/monitoring/grafana/datasource.yml
+++ b/docker/monitoring/grafana/datasource.yml
@@ -3,7 +3,7 @@ apiVersion: 1
 datasources:
 - name: Prometheus
   type: prometheus
-  url: http://prometheus:9090 
+  url: http://localhost:19090 
   isDefault: true
   access: proxy
   editable: true

--- a/docker/monitoring/local-prometheus-on.sh
+++ b/docker/monitoring/local-prometheus-on.sh
@@ -22,5 +22,6 @@ echo -e "\nStart Prometheus:\n"
 
 docker run --rm -d --name=prometheus \
     --net=host \
+    -p 9090:9090 \
     -v ${PWD}/${CONF}:/etc/prometheus/${CONF} \
     prom/prometheus

--- a/docker/monitoring/prometheus-off.sh
+++ b/docker/monitoring/prometheus-off.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 cd $(dirname $0)
-. ./_params.sh
-
 
 docker ps -a -q -f "network=${NETWORK}" -f "name=prometheus" | while read id
 do

--- a/docker/monitoring/prometheus-on.sh
+++ b/docker/monitoring/prometheus-on.sh
@@ -4,6 +4,11 @@ cd $(dirname $0)
 NETWORK=u2u
 CONF=prometheus/prometheus.yml
 
+set -e
+
+docker network inspect ${NETWORK} &>/dev/null || \
+docker network create ${NETWORK}
+
 cat << HEADER > $CONF
 global:
   # How frequently to scrape targets by default.
@@ -14,7 +19,7 @@ HEADER
 cat << NODE >> $CONF
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:19090']
+      - targets: ['prometheus:19090']
 NODE
 
 echo -e "\nStart Prometheus:\n"

--- a/docker/monitoring/prometheus/prometheus.yml
+++ b/docker/monitoring/prometheus/prometheus.yml
@@ -3,6 +3,6 @@ global:
   scrape_interval: 1m
 
 scrape_configs:
-  - job_name: 'txgen0'
+  - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:19090']

--- a/metrics/prometheus/apdapter.go
+++ b/metrics/prometheus/apdapter.go
@@ -9,8 +9,7 @@ import (
 )
 
 // NewCollector constructor.
-func NewCollector(opts prometheus.Opts, metric interface{}, fields ...string) *Collector {
-
+func PrometheusCollector(opts prometheus.Opts, metric interface{}, fields ...string) *Collector {
 	return &Collector{
 		Metric: &Metric{
 			desc: prometheus.NewDesc(

--- a/metrics/prometheus/handler.go
+++ b/metrics/prometheus/handler.go
@@ -11,8 +11,8 @@ import (
 
 var logger = log.New("module", "prometheus")
 
-// ListenTo serves prometheus connections.
-func ListenTo(endpoint string, reg metrics.Registry) {
+// PrometheusListener serves prometheus connections.
+func PrometheusListener(endpoint string, reg metrics.Registry) {
 	if reg == nil {
 		reg = metrics.DefaultRegistry
 	}

--- a/metrics/prometheus/metrics.go
+++ b/metrics/prometheus/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var namespace = "lachesis"
+var namespace = "u2u"
 
 // SetNamespace for metrics.
 func SetNamespace(s string) {
@@ -50,15 +50,15 @@ func convertToPrometheusMetric(name string, m interface{}) (prometheus.Collector
 		})
 
 	case metrics.Meter:
-		collector = NewCollector(opts, metric,
+		collector = PrometheusCollector(opts, metric,
 			"rate1m", "rate5m", "rate15m", "rate")
 
 	case metrics.Histogram:
-		collector = NewCollector(opts, metric,
+		collector = PrometheusCollector(opts, metric,
 			"min", "max", "mean")
 
 	case metrics.Timer, metrics.ResettingTimer:
-		collector = NewCollector(opts, metric,
+		collector = PrometheusCollector(opts, metric,
 			"min", "max", "mean", "rate1m", "rate5m", "rate15m", "rate")
 
 	default:

--- a/utils/prometheus/prometheus.go
+++ b/utils/prometheus/prometheus.go
@@ -13,7 +13,7 @@ import (
 )
 
 var PrometheusEndpointFlag = cli.StringFlag{
-	Name:  "monitoring.prometheus.endpoint",
+	Name:  "metrics.prometheus.endpoint",
 	Usage: "Prometheus API endpoint to report metrics to",
 	Value: ":19090",
 }
@@ -24,7 +24,7 @@ func SetupPrometheus(ctx *cli.Context) {
 	}
 	prometheus.SetNamespace("u2u")
 	var endpoint = ctx.GlobalString(PrometheusEndpointFlag.Name)
-	prometheus.ListenTo(endpoint, nil)
+	prometheus.PrometheusListener(endpoint, nil)
 }
 
 var (


### PR DESCRIPTION
This PR setups Prometheus and some related features to monitor metrics
### Checklist:
- [x] Setup Prometheus config + flag + running bash
- [X] Add docker-compose file for building Prometheus and Grafana container
### Updated Checklist (03/08/2023):
- [x] Modify prometheus source
- [x] Initiate Readme for running prometheus and related service container.
- [x] Checking prometheus endpoint and starting metrics endpoint 
- [ ] Moving prometheus folder to utils package (Pending - waiting for updating go-eth library)