### PR TITLE
Update ldb-1 DB preset

### DIFF
--- a/integration/presets.go
+++ b/integration/presets.go
@@ -158,10 +158,17 @@ func Ldb1RoutingConfig() RoutingConfig {
 				Type: "leveldb-fsh",
 				Name: "main",
 			},
+			"gossip/e": {
+				Type: "leveldb-fsh",
+				Name: "events",
+			},
+			"evm/M": {
+				Type: "leveldb-drc",
+				Name: "evm-data",
+			},
 			"evm-logs": {
-				Type:  "leveldb-fsh",
-				Name:  "main",
-				Table: "L",
+				Type: "leveldb-fsh",
+				Name: "evm-logs",
 			},
 			"gossip-%d": {
 				Type:  "leveldb-fsh",
@@ -181,13 +188,25 @@ func Ldb1RoutingConfig() RoutingConfig {
 func Ldb1RuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
+			"evm-data": {
+				Cache:   scale(480 * opt.MiB),
+				Fdlimit: fdlimit*480/1400 + 1,
+			},
+			"evm-logs": {
+				Cache:   scale(260 * opt.MiB),
+				Fdlimit: fdlimit*260/1400 + 1,
+			},
 			"main": {
-				Cache:   scale(900 * opt.MiB),
-				Fdlimit: fdlimit*900/1000 + 1,
+				Cache:   scale(320 * opt.MiB),
+				Fdlimit: fdlimit*320/1400 + 1,
+			},
+			"events": {
+				Cache:   scale(240 * opt.MiB),
+				Fdlimit: fdlimit*240/1400 + 1,
 			},
 			"epoch-%d": {
 				Cache:   scale(100 * opt.MiB),
-				Fdlimit: fdlimit*100/1000 + 1,
+				Fdlimit: fdlimit*100/1400 + 1,
 			},
 			"": {
 				Cache:   64 * opt.MiB,
@@ -201,8 +220,20 @@ func Ldb1GenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCac
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(3000 * opt.MiB),
-				Fdlimit: fdlimit,
+				Cache:   scale(1000 * opt.MiB),
+				Fdlimit: fdlimit*1000/3000 + 1,
+			},
+			"evm-data": {
+				Cache:   scale(1000 * opt.MiB),
+				Fdlimit: fdlimit*1000/3000 + 1,
+			},
+			"evm-logs": {
+				Cache:   scale(1000 * opt.MiB),
+				Fdlimit: fdlimit*1000/3000 + 1,
+			},
+			"events": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"epoch-%d": {
 				Cache:   scale(1 * opt.MiB),


### PR DESCRIPTION
This PR change the `ldb-1` preset into a `pdb-1`-like preset where data is split between 5 DBs instead of 2. Instead of creating new `ldb-2` layout to resolve the issue https://github.com/unicornultrafoundation/go-u2u/issues/10, I changed the existing `ldb-1`, so users may either transform the DB with `db transform` or continue using the old `ldb-1` with this config:

```
[DBs.Routing.Table.""]
Type = "leveldb-fsh"
Name = ""
Table = ""
NoDrop = false

[DBs.Routing.Table.evm]
Type = "leveldb-fsh"
Name = "main"
Table = ""
NoDrop = false

[DBs.Routing.Table.evm-logs]
Type = "leveldb-fsh"
Name = "main"
Table = "L"
NoDrop = false

[DBs.Routing.Table.gossip]
Type = "leveldb-fsh"
Name = "main"
Table = ""
NoDrop = false

[DBs.Routing.Table."gossip-%d"]
Type = "leveldb-fsh"
Name = "epoch-%d"
Table = "G"
NoDrop = false

[DBs.Routing.Table.lachesis]
Type = "leveldb-fsh"
Name = "main"
Table = "C"
NoDrop = false

[DBs.Routing.Table."lachesis-%d"]
Type = "leveldb-fsh"
Name = "epoch-%d"
Table = "L"
NoDrop = true

[DBs.RuntimeCache.Table.""]
Cache = 67108864
Fdlimit = 5243

[DBs.RuntimeCache.Table."epoch-%d"]
Cache = 104857600
Fdlimit = 52429

[DBs.RuntimeCache.Table.main]
Cache = 943718400
Fdlimit = 471860

[DBs.GenesisCache.Table.""]
Cache = 16777216
Fdlimit = 5243

[DBs.GenesisCache.Table."epoch-%d"]
Cache = 1048576
Fdlimit = 175

[DBs.GenesisCache.Table.main]
Cache = 3145728000
Fdlimit = 52428
```