### PR TITLE
Fix of tmp db size metric

### DIFF
--- a/integration/metric.go
+++ b/integration/metric.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -140,24 +141,34 @@ func (ds *StoreWithMetrics) meter(refresh time.Duration) {
 	errc <- merr
 }
 
+var tmpDbNameMask = regexp.MustCompile("^([A-z]+)(-[0-9]+)$")
+
+func genericNameOfTmpDB(name string) string {
+	match := tmpDbNameMask.FindStringSubmatch(name)
+	if len(match) == 3 {
+		return match[1] + "-tmp"
+	} else {
+		return name
+	}
+}
+
 func (db *DBProducerWithMetrics) OpenDB(name string) (u2udb.Store, error) {
 	ds, err := db.IterableDBProducer.OpenDB(name)
 	if err != nil {
 		return nil, err
 	}
 	dm := WrapStoreWithMetrics(ds)
-	if strings.HasPrefix(name, "gossip-") || strings.HasPrefix(name, "hashgraph-") || strings.HasPrefix(name, "epoch-") {
-		name = "epochs"
-	}
-	logger := log.New("database", name)
-	dm.log = logger
 
-	name = "u2u/chaindata/" + strings.ReplaceAll(name, "-", "_")
-	dm.diskReadMeter = metrics.GetOrRegisterMeter(name+"/disk/read", nil)
-	dm.diskWriteMeter = metrics.GetOrRegisterMeter(name+"/disk/write", nil)
+	name = genericNameOfTmpDB(name)
+
+	dm.log = log.New("database", name)
+
+	metric := "u2u/chaindata/" + strings.ReplaceAll(name, "-", "_")
+	dm.diskReadMeter = metrics.GetOrRegisterMeter(metric+"/disk/read", nil)
+	dm.diskWriteMeter = metrics.GetOrRegisterMeter(metric+"/disk/write", nil)
 	// reset size metric as far as previous db will be dropped soon
-	metrics.Unregister(name + "/disk/size")
-	dm.diskSizeGauge = metrics.NewRegisteredGauge(name+"/disk/size", nil)
+	metrics.Unregister(metric + "/disk/size")
+	dm.diskSizeGauge = metrics.NewRegisteredGauge(metric+"/disk/size", nil)
 
 	// Start up the metrics gathering and return
 	go dm.meter(metricsGatheringInterval)

--- a/integration/metric_test.go
+++ b/integration/metric_test.go
@@ -1,0 +1,26 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericNameOfTmpDB(t *testing.T) {
+	require := require.New(t)
+
+	for name, exp := range map[string]string{
+		"":              "",
+		"main":          "main",
+		"main-single":   "main-single",
+		"lachesis-0":    "lachesis-tmp",
+		"lachesis-0999": "lachesis-tmp",
+		"gossip-50":     "gossip-tmp",
+		"epoch-1":       "epoch-tmp",
+		"xxx-1a":        "xxx-1a",
+		"123":           "123",
+	} {
+		got := genericNameOfTmpDB(name)
+		require.Equal(exp, got, name)
+	}
+}


### PR DESCRIPTION
Replaces infinite number of metrics for each tmp DB with single generic metric for each kind of tmp DB.
Makes it easier to build a dashboard, prevents the leaks