### PR TITLE
Randomize output of eth_feeHistory to mimic ETH API

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"runtime"
 	"strings"
 	"sync"
@@ -104,6 +105,7 @@ type feeHistoryResult struct {
 	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
 	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
 	GasUsedRatio []float64        `json:"gasUsedRatio"`
+	Note         string           `json:"note"`
 }
 
 var errInvalidPercentile = errors.New("invalid reward percentile")
@@ -143,17 +145,35 @@ func (s *PublicEthereumAPI) FeeHistory(ctx context.Context, blockCount rpc.Decim
 
 	baseFee := s.b.MinGasPrice()
 
-	tips := make([]*hexutil.Big, 0, len(rewardPercentiles))
+	tips := make([]*big.Int, 0, len(rewardPercentiles))
 	for _, p := range rewardPercentiles {
 		tip := s.b.SuggestGasTipCap(ctx, uint64(gasprice.DecimalUnit*p/100.0))
-		tips = append(tips, (*hexutil.Big)(tip))
+		tips = append(tips, tip)
 	}
 	res.OldestBlock.ToInt().SetUint64(uint64(oldest))
 	for i := uint64(0); i < uint64(last-oldest+1); i++ {
-		res.Reward = append(res.Reward, tips)
+		// randomize the output to mimic the ETH API eth_feeHistory for compatibility reasons
+		rTips := make([]*hexutil.Big, 0, len(tips))
+		for _, t := range tips {
+			rTip := t
+			// don't randomize last iteration
+			if i < uint64(last-oldest) {
+				// increase by up to 2% randomly
+				rTip = new(big.Int).Mul(t, big.NewInt(int64(rand.Intn(gasprice.DecimalUnit/50)+gasprice.DecimalUnit)))
+				rTip.Div(rTip, big.NewInt(gasprice.DecimalUnit))
+			}
+			rTips = append(rTips, (*hexutil.Big)(rTip))
+		}
+		res.Reward = append(res.Reward, rTips)
 		res.BaseFee = append(res.BaseFee, (*hexutil.Big)(baseFee))
-		res.GasUsedRatio = append(res.GasUsedRatio, 0.99)
+		r := rand.New(rand.NewSource(int64(oldest) + int64(i)))
+		res.GasUsedRatio = append(res.GasUsedRatio, 0.9+r.Float64()*0.1)
 	}
+	res.Note = `In the U2U network, the eth_feeHistory method operates slightly differently due to the network's unique consensus mechanism. ` +
+		`Here, instead of returning a range of gas tip values from requested blocks, ` +
+		`it provides a singular estimated gas tip based on a defined confidence level (indicated by the percentile parameter). ` +
+		`This approach means that while you will receive replicated (and randomized) reward values across the requested blocks, ` +
+		`the average or median of these values remains consistent with the intended gas tip.`
 	return res, nil
 }
 


### PR DESCRIPTION
In ETH API, `eth_feeHistory` is originally intended to return the history of `gas tip`s in recent blocks, which has to be used as a data source for a custom `gas tip` estimation. Typically, the resulting `gas tip` is expected to be an average or a median of the historic median values.
The same approach cannot be used in U2U due to the leaderless and asynchronous nature of the consensus algorithm. Instead, `eth_feeHistory` itself performs the estimation of `gas tip` and calculates a single `gas tip`, where `percentile` is interpreted as a confidence level (higher -> larger fee). This value is then copied for each requested block, in a case if multiple blocks were requested.
We expect that users can reuse the same code for `gas tip` estimation which they use for ETH, because both an average or a median of the copied values will still be equal to the intended value. However, it causes a confusion as it's apparent that the output doesn't match the ETH API description of the method.

This PR randomizes the copied `gas tip` by up to 2% upward in order to closer cosmetically mimic the original ETH API variant of the method. The `gas tip` for last requested block is left as-is without randomization.
The PR adds note to output of `eth_feeHistory` which explains the difference in output.

This way, we endeavor to balance fidelity to the original API design with the adaptations necessary for U2U unique architecture, thereby providing users with a tool that is both familiar and optimized for the new context.