### PR TITLE
Implement `EIP712TxType` (closes #91)

### DIFF
--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -94,18 +94,19 @@ func (tx *AccessListTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *AccessListTx) txType() byte           { return AccessListTxType }
-func (tx *AccessListTx) chainID() *big.Int      { return tx.ChainID }
-func (tx *AccessListTx) protected() bool        { return true }
-func (tx *AccessListTx) accessList() AccessList { return tx.AccessList }
-func (tx *AccessListTx) data() []byte           { return tx.Data }
-func (tx *AccessListTx) gas() uint64            { return tx.Gas }
-func (tx *AccessListTx) gasPrice() *big.Int     { return tx.GasPrice }
-func (tx *AccessListTx) gasTipCap() *big.Int    { return tx.GasPrice }
-func (tx *AccessListTx) gasFeeCap() *big.Int    { return tx.GasPrice }
-func (tx *AccessListTx) value() *big.Int        { return tx.Value }
-func (tx *AccessListTx) nonce() uint64          { return tx.Nonce }
-func (tx *AccessListTx) to() *common.Address    { return tx.To }
+func (tx *AccessListTx) txType() byte                      { return AccessListTxType }
+func (tx *AccessListTx) chainID() *big.Int                 { return tx.ChainID }
+func (tx *AccessListTx) protected() bool                   { return true }
+func (tx *AccessListTx) accessList() AccessList            { return tx.AccessList }
+func (tx *AccessListTx) data() []byte                      { return tx.Data }
+func (tx *AccessListTx) gas() uint64                       { return tx.Gas }
+func (tx *AccessListTx) gasPrice() *big.Int                { return tx.GasPrice }
+func (tx *AccessListTx) gasTipCap() *big.Int               { return tx.GasPrice }
+func (tx *AccessListTx) gasFeeCap() *big.Int               { return tx.GasPrice }
+func (tx *AccessListTx) value() *big.Int                   { return tx.Value }
+func (tx *AccessListTx) nonce() uint64                     { return tx.Nonce }
+func (tx *AccessListTx) to() *common.Address               { return tx.To }
+func (tx *AccessListTx) paymasterParams() *PaymasterParams { return nil }
 
 func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -82,18 +82,19 @@ func (tx *DynamicFeeTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *DynamicFeeTx) txType() byte           { return DynamicFeeTxType }
-func (tx *DynamicFeeTx) chainID() *big.Int      { return tx.ChainID }
-func (tx *DynamicFeeTx) protected() bool        { return true }
-func (tx *DynamicFeeTx) accessList() AccessList { return tx.AccessList }
-func (tx *DynamicFeeTx) data() []byte           { return tx.Data }
-func (tx *DynamicFeeTx) gas() uint64            { return tx.Gas }
-func (tx *DynamicFeeTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
-func (tx *DynamicFeeTx) gasTipCap() *big.Int    { return tx.GasTipCap }
-func (tx *DynamicFeeTx) gasPrice() *big.Int     { return tx.GasFeeCap }
-func (tx *DynamicFeeTx) value() *big.Int        { return tx.Value }
-func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
-func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
+func (tx *DynamicFeeTx) txType() byte                      { return DynamicFeeTxType }
+func (tx *DynamicFeeTx) chainID() *big.Int                 { return tx.ChainID }
+func (tx *DynamicFeeTx) protected() bool                   { return true }
+func (tx *DynamicFeeTx) accessList() AccessList            { return tx.AccessList }
+func (tx *DynamicFeeTx) data() []byte                      { return tx.Data }
+func (tx *DynamicFeeTx) gas() uint64                       { return tx.Gas }
+func (tx *DynamicFeeTx) gasFeeCap() *big.Int               { return tx.GasFeeCap }
+func (tx *DynamicFeeTx) gasTipCap() *big.Int               { return tx.GasTipCap }
+func (tx *DynamicFeeTx) gasPrice() *big.Int                { return tx.GasFeeCap }
+func (tx *DynamicFeeTx) value() *big.Int                   { return tx.Value }
+func (tx *DynamicFeeTx) nonce() uint64                     { return tx.Nonce }
+func (tx *DynamicFeeTx) to() *common.Address               { return tx.To }
+func (tx *DynamicFeeTx) paymasterParams() *PaymasterParams { return nil }
 
 func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -91,17 +91,18 @@ func (tx *LegacyTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *LegacyTx) txType() byte           { return LegacyTxType }
-func (tx *LegacyTx) chainID() *big.Int      { return deriveChainId(tx.V) }
-func (tx *LegacyTx) accessList() AccessList { return nil }
-func (tx *LegacyTx) data() []byte           { return tx.Data }
-func (tx *LegacyTx) gas() uint64            { return tx.Gas }
-func (tx *LegacyTx) gasPrice() *big.Int     { return tx.GasPrice }
-func (tx *LegacyTx) gasTipCap() *big.Int    { return tx.GasPrice }
-func (tx *LegacyTx) gasFeeCap() *big.Int    { return tx.GasPrice }
-func (tx *LegacyTx) value() *big.Int        { return tx.Value }
-func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
-func (tx *LegacyTx) to() *common.Address    { return tx.To }
+func (tx *LegacyTx) txType() byte                      { return LegacyTxType }
+func (tx *LegacyTx) chainID() *big.Int                 { return deriveChainId(tx.V) }
+func (tx *LegacyTx) accessList() AccessList            { return nil }
+func (tx *LegacyTx) data() []byte                      { return tx.Data }
+func (tx *LegacyTx) gas() uint64                       { return tx.Gas }
+func (tx *LegacyTx) gasPrice() *big.Int                { return tx.GasPrice }
+func (tx *LegacyTx) gasTipCap() *big.Int               { return tx.GasPrice }
+func (tx *LegacyTx) gasFeeCap() *big.Int               { return tx.GasPrice }
+func (tx *LegacyTx) value() *big.Int                   { return tx.Value }
+func (tx *LegacyTx) nonce() uint64                     { return tx.Nonce }
+func (tx *LegacyTx) to() *common.Address               { return tx.To }
+func (tx *LegacyTx) paymasterParams() *PaymasterParams { return nil }
 
 func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -45,6 +45,7 @@ const (
 	LegacyTxType = iota
 	AccessListTxType
 	DynamicFeeTxType
+	EIP712TxType = 0x71
 )
 
 // Transaction is an Ethereum transaction.
@@ -82,6 +83,7 @@ type TxData interface {
 	value() *big.Int
 	nonce() uint64
 	to() *common.Address
+	paymasterParams() *PaymasterParams
 
 	rawSignatureValues() (v, r, s *big.Int)
 	setSignatureValues(chainID, v, r, s *big.Int)
@@ -298,6 +300,10 @@ func (tx *Transaction) Cost() *big.Int {
 	total := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
 	total.Add(total, tx.Value())
 	return total
+}
+
+func (tx *Transaction) PaymasterParams() *PaymasterParams {
+	return tx.inner.paymasterParams()
 }
 
 // RawSignatureValues returns the V, R, S signature values of the transaction.

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -232,13 +232,11 @@ func (s eip712Signer) Hash(tx *Transaction) common.Hash {
 		[]interface{}{
 			s.chainId,
 			tx.Nonce(),
-			tx.GasTipCap(),
-			tx.GasFeeCap(),
+			tx.GasPrice(),
 			tx.Gas(),
 			tx.To(),
 			tx.Value(),
 			tx.Data(),
-			tx.AccessList(),
 			tx.PaymasterParams(),
 		})
 }

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,6 +40,8 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
+	case config.IsEIP712(blockNumber):
+		signer = NewEIP712Signer(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
 	case config.IsBerlin(blockNumber):
@@ -63,6 +65,9 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
+		if config.EIP712Block != nil {
+			return NewEIP712Signer(config.ChainID)
+		}
 		if config.LondonBlock != nil {
 			return NewLondonSigner(config.ChainID)
 		}
@@ -87,7 +92,7 @@ func LatestSignerForChainID(chainID *big.Int) Signer {
 	if chainID == nil {
 		return HomesteadSigner{}
 	}
-	return NewLondonSigner(chainID)
+	return NewEIP712Signer(chainID)
 }
 
 // SignTx signs the transaction using the given signer and private key.
@@ -168,6 +173,74 @@ type Signer interface {
 
 	// Equal returns true if the given signer is the same as the receiver.
 	Equal(Signer) bool
+}
+
+type eip712Signer struct{ londonSigner }
+
+// NewEIP712Signer returns a signer that accepts
+// - EIP-712 typed transactions,
+// - EIP-1559 dynamic fee transactions,
+// - EIP-2930 access list transactions,
+// - EIP-155 replay protected transactions, and
+// - legacy Homestead transactions.
+func NewEIP712Signer(chainId *big.Int) Signer {
+	return eip712Signer{londonSigner{eip2930Signer{NewEIP155Signer(chainId)}}}
+}
+
+func (s eip712Signer) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() != EIP712TxType {
+		return s.londonSigner.Sender(tx)
+	}
+	V, R, S := tx.RawSignatureValues()
+	// EIP712 txs are defined to use 0 and 1 as their recovery
+	// id, add 27 to become equivalent to unprotected Homestead signatures.
+	V = new(big.Int).Add(V, big.NewInt(27))
+	if tx.ChainId().Cmp(s.chainId) != 0 {
+		return common.Address{}, ErrInvalidChainId
+	}
+	return recoverPlain(s.Hash(tx), R, S, V, true)
+}
+
+func (s eip712Signer) Equal(s2 Signer) bool {
+	x, ok := s2.(eip712Signer)
+	return ok && x.chainId.Cmp(s.chainId) == 0
+}
+
+func (s eip712Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	txdata, ok := tx.inner.(*EIP712Tx)
+	if !ok {
+		return s.londonSigner.SignatureValues(tx, sig)
+	}
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
+		return nil, nil, nil, ErrInvalidChainId
+	}
+	R, S, _ = decodeSignature(sig)
+	V = big.NewInt(int64(sig[64]))
+	return R, S, V, nil
+}
+
+// Hash returns the hash to be signed by the sender.
+// It does not uniquely identify the transaction.
+func (s eip712Signer) Hash(tx *Transaction) common.Hash {
+	if tx.Type() != EIP712TxType {
+		return s.londonSigner.Hash(tx)
+	}
+	return prefixedRlpHash(
+		tx.Type(),
+		[]interface{}{
+			s.chainId,
+			tx.Nonce(),
+			tx.GasTipCap(),
+			tx.GasFeeCap(),
+			tx.Gas(),
+			tx.To(),
+			tx.Value(),
+			tx.Data(),
+			tx.AccessList(),
+			tx.PaymasterParams(),
+		})
 }
 
 type londonSigner struct{ eip2930Signer }

--- a/core/types/tx_eip_712.go
+++ b/core/types/tx_eip_712.go
@@ -1,0 +1,79 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/unicornultrafoundation/go-u2u/common"
+)
+
+type PaymasterParams struct {
+	Paymaster      *common.Address
+	PaymasterInput []byte
+}
+
+// EIP712Tx is the transaction data of regular Ethereum transactions.
+type EIP712Tx struct {
+	ChainID         *big.Int
+	Nonce           uint64          // nonce of sender account
+	GasPrice        *big.Int        // wei per gas
+	Gas             uint64          // gas limit
+	To              *common.Address `rlp:"nil"` // nil means contract creation
+	Value           *big.Int        // wei amount
+	Data            []byte          // contract invocation input data
+	PaymasterParams *PaymasterParams
+	V, R, S         *big.Int // signature values
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *EIP712Tx) copy() TxData {
+	cpy := &EIP712Tx{
+		Nonce: tx.Nonce,
+		To:    tx.To, // TODO: copy pointed-to address
+		Data:  common.CopyBytes(tx.Data),
+		Gas:   tx.Gas,
+		// These are initialized below.
+		Value:    new(big.Int),
+		GasPrice: new(big.Int),
+		V:        new(big.Int),
+		R:        new(big.Int),
+		S:        new(big.Int),
+	}
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	if tx.GasPrice != nil {
+		cpy.GasPrice.Set(tx.GasPrice)
+	}
+	if tx.V != nil {
+		cpy.V.Set(tx.V)
+	}
+	if tx.R != nil {
+		cpy.R.Set(tx.R)
+	}
+	if tx.S != nil {
+		cpy.S.Set(tx.S)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *EIP712Tx) txType() byte                      { return EIP712TxType }
+func (tx *EIP712Tx) chainID() *big.Int                 { return tx.ChainID }
+func (tx *EIP712Tx) accessList() AccessList            { return nil }
+func (tx *EIP712Tx) data() []byte                      { return tx.Data }
+func (tx *EIP712Tx) gas() uint64                       { return tx.Gas }
+func (tx *EIP712Tx) gasPrice() *big.Int                { return tx.GasPrice }
+func (tx *EIP712Tx) gasTipCap() *big.Int               { return tx.GasPrice }
+func (tx *EIP712Tx) gasFeeCap() *big.Int               { return tx.GasPrice }
+func (tx *EIP712Tx) value() *big.Int                   { return tx.Value }
+func (tx *EIP712Tx) nonce() uint64                     { return tx.Nonce }
+func (tx *EIP712Tx) to() *common.Address               { return tx.To }
+func (tx *EIP712Tx) paymasterParams() *PaymasterParams { return tx.PaymasterParams }
+
+func (tx *EIP712Tx) rawSignatureValues() (v, r, s *big.Int) {
+	return tx.V, tx.R, tx.S
+}
+
+func (tx *EIP712Tx) setSignatureValues(chainID, v, r, s *big.Int) {
+	tx.V, tx.R, tx.S = v, r, s
+}

--- a/core/types/tx_eip_712.go
+++ b/core/types/tx_eip_712.go
@@ -14,12 +14,12 @@ type PaymasterParams struct {
 // EIP712Tx is the transaction data of regular Ethereum transactions.
 type EIP712Tx struct {
 	ChainID         *big.Int
-	Nonce           uint64          // nonce of sender account
-	GasPrice        *big.Int        // wei per gas
-	Gas             uint64          // gas limit
+	Nonce           uint64
+	GasPrice        *big.Int
+	Gas             uint64
 	To              *common.Address `rlp:"nil"` // nil means contract creation
-	Value           *big.Int        // wei amount
-	Data            []byte          // contract invocation input data
+	Value           *big.Int
+	Data            []byte
 	PaymasterParams *PaymasterParams
 	V, R, S         *big.Int // signature values
 }
@@ -27,12 +27,14 @@ type EIP712Tx struct {
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *EIP712Tx) copy() TxData {
 	cpy := &EIP712Tx{
-		Nonce: tx.Nonce,
-		To:    tx.To, // TODO: copy pointed-to address
-		Data:  common.CopyBytes(tx.Data),
-		Gas:   tx.Gas,
+		Nonce:           tx.Nonce,
+		To:              tx.To, // TODO: copy pointed-to address
+		Data:            common.CopyBytes(tx.Data),
+		Gas:             tx.Gas,
+		PaymasterParams: tx.PaymasterParams,
 		// These are initialized below.
 		Value:    new(big.Int),
+		ChainID:  new(big.Int),
 		GasPrice: new(big.Int),
 		V:        new(big.Int),
 		R:        new(big.Int),
@@ -40,6 +42,9 @@ func (tx *EIP712Tx) copy() TxData {
 	}
 	if tx.Value != nil {
 		cpy.Value.Set(tx.Value)
+	}
+	if tx.ChainID != nil {
+		cpy.ChainID.Set(tx.ChainID)
 	}
 	if tx.GasPrice != nil {
 		cpy.GasPrice.Set(tx.GasPrice)

--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -84,4 +84,7 @@ var (
 
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")
+
+	// ErrInvalidPaymasterParams is returned if the paymaster params is malformed.
+	ErrInvalidPaymasterParams = errors.New("invalid paymaster params")
 )

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -235,6 +235,7 @@ type TxPool struct {
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
 	eip2718  bool // Fork indicator whether we are using EIP-2718 type transactions.
 	eip1559  bool // Fork indicator whether we are using EIP-1559 type transactions.
+	eip712   bool // Fork indicator whether we are using EIP-712 type transactions.
 
 	currentState  *state.StateDB // Current state in the blockchain head
 	pendingNonces *txNoncer      // Pending state tracking virtual nonces
@@ -590,6 +591,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if !pool.eip1559 && tx.Type() == types.DynamicFeeTxType {
 		return ErrTxTypeNotSupported
 	}
+	// Reject EIP-712 transactions until EIP-712 activates.
+	if !pool.eip712 && tx.Type() == types.EIP712TxType {
+		return ErrTxTypeNotSupported
+	}
 	// Reject transactions over defined size to prevent DOS attacks
 	if uint64(tx.Size()) > txMaxSize {
 		return ErrOversizedData
@@ -649,6 +654,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
+	}
+	if !(tx.Type() == types.EIP712TxType && tx.PaymasterParams() != nil && tx.PaymasterParams().Paymaster != nil) {
+		return ErrInvalidPaymasterParams
 	}
 	return nil
 }
@@ -1321,6 +1329,7 @@ func (pool *TxPool) reset(oldHead, newHead *EvmHeader) {
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 	pool.eip2718 = pool.chainconfig.IsBerlin(next)
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
+	pool.eip712 = pool.chainconfig.IsEIP712(next)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -655,7 +655,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
 	}
-	if !(tx.Type() == types.EIP712TxType && tx.PaymasterParams() != nil && tx.PaymasterParams().Paymaster != nil) {
+	if tx.Type() == types.EIP712TxType && (tx.PaymasterParams() == nil || tx.PaymasterParams().Paymaster == nil) {
 		return ErrInvalidPaymasterParams
 	}
 	return nil

--- a/u2u/contracts/eip712/IAccount.go
+++ b/u2u/contracts/eip712/IAccount.go
@@ -1,0 +1,303 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package eip712
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	u2u "github.com/unicornultrafoundation/go-u2u"
+	"github.com/unicornultrafoundation/go-u2u/accounts/abi"
+	"github.com/unicornultrafoundation/go-u2u/accounts/abi/bind"
+	"github.com/unicornultrafoundation/go-u2u/common"
+	"github.com/unicornultrafoundation/go-u2u/core/types"
+	"github.com/unicornultrafoundation/go-u2u/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = u2u.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	PaymasterInput         []byte
+}
+
+// IAccountMetaData contains all meta data concerning the IAccount contract.
+var IAccountMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"executeTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"executeTransactionFromOutside\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"payForTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_possibleSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"prepareForPaymaster\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magic\",\"type\":\"bytes4\"}],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
+}
+
+// IAccountABI is the input ABI used to generate the binding from.
+// Deprecated: Use IAccountMetaData.ABI instead.
+var IAccountABI = IAccountMetaData.ABI
+
+// IAccount is an auto generated Go binding around an Ethereum contract.
+type IAccount struct {
+	IAccountCaller     // Read-only binding to the contract
+	IAccountTransactor // Write-only binding to the contract
+	IAccountFilterer   // Log filterer for contract events
+}
+
+// IAccountCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IAccountCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IAccountTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IAccountTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IAccountFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IAccountFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IAccountSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IAccountSession struct {
+	Contract     *IAccount         // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IAccountCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IAccountCallerSession struct {
+	Contract *IAccountCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts   // Call options to use throughout this session
+}
+
+// IAccountTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IAccountTransactorSession struct {
+	Contract     *IAccountTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// IAccountRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IAccountRaw struct {
+	Contract *IAccount // Generic contract binding to access the raw methods on
+}
+
+// IAccountCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IAccountCallerRaw struct {
+	Contract *IAccountCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IAccountTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IAccountTransactorRaw struct {
+	Contract *IAccountTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIAccount creates a new instance of IAccount, bound to a specific deployed contract.
+func NewIAccount(address common.Address, backend bind.ContractBackend) (*IAccount, error) {
+	contract, err := bindIAccount(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IAccount{IAccountCaller: IAccountCaller{contract: contract}, IAccountTransactor: IAccountTransactor{contract: contract}, IAccountFilterer: IAccountFilterer{contract: contract}}, nil
+}
+
+// NewIAccountCaller creates a new read-only instance of IAccount, bound to a specific deployed contract.
+func NewIAccountCaller(address common.Address, caller bind.ContractCaller) (*IAccountCaller, error) {
+	contract, err := bindIAccount(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IAccountCaller{contract: contract}, nil
+}
+
+// NewIAccountTransactor creates a new write-only instance of IAccount, bound to a specific deployed contract.
+func NewIAccountTransactor(address common.Address, transactor bind.ContractTransactor) (*IAccountTransactor, error) {
+	contract, err := bindIAccount(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IAccountTransactor{contract: contract}, nil
+}
+
+// NewIAccountFilterer creates a new log filterer instance of IAccount, bound to a specific deployed contract.
+func NewIAccountFilterer(address common.Address, filterer bind.ContractFilterer) (*IAccountFilterer, error) {
+	contract, err := bindIAccount(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IAccountFilterer{contract: contract}, nil
+}
+
+// bindIAccount binds a generic wrapper to an already deployed contract.
+func bindIAccount(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(IAccountABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IAccount *IAccountRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IAccount.Contract.IAccountCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IAccount *IAccountRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IAccount.Contract.IAccountTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IAccount *IAccountRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IAccount.Contract.IAccountTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IAccount *IAccountCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IAccount.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IAccount *IAccountTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IAccount.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IAccount *IAccountTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IAccount.Contract.contract.Transact(opts, method, params...)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0x53e38206.
+//
+// Solidity: function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactor) ExecuteTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.contract.Transact(opts, "executeTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0x53e38206.
+//
+// Solidity: function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountSession) ExecuteTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.ExecuteTransaction(&_IAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0x53e38206.
+//
+// Solidity: function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactorSession) ExecuteTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.ExecuteTransaction(&_IAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0x494290c6.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactor) ExecuteTransactionFromOutside(opts *bind.TransactOpts, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.contract.Transact(opts, "executeTransactionFromOutside", _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0x494290c6.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountSession) ExecuteTransactionFromOutside(_transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.ExecuteTransactionFromOutside(&_IAccount.TransactOpts, _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0x494290c6.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactorSession) ExecuteTransactionFromOutside(_transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.ExecuteTransactionFromOutside(&_IAccount.TransactOpts, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xa0b4c91a.
+//
+// Solidity: function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactor) PayForTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.contract.Transact(opts, "payForTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xa0b4c91a.
+//
+// Solidity: function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountSession) PayForTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.PayForTransaction(&_IAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xa0b4c91a.
+//
+// Solidity: function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactorSession) PayForTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.PayForTransaction(&_IAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0x07192996.
+//
+// Solidity: function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactor) PrepareForPaymaster(opts *bind.TransactOpts, _txHash [32]byte, _possibleSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.contract.Transact(opts, "prepareForPaymaster", _txHash, _possibleSignedHash, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0x07192996.
+//
+// Solidity: function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountSession) PrepareForPaymaster(_txHash [32]byte, _possibleSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.PrepareForPaymaster(&_IAccount.TransactOpts, _txHash, _possibleSignedHash, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0x07192996.
+//
+// Solidity: function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns()
+func (_IAccount *IAccountTransactorSession) PrepareForPaymaster(_txHash [32]byte, _possibleSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.PrepareForPaymaster(&_IAccount.TransactOpts, _txHash, _possibleSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x9c27706d.
+//
+// Solidity: function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_IAccount *IAccountTransactor) ValidateTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.contract.Transact(opts, "validateTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x9c27706d.
+//
+// Solidity: function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_IAccount *IAccountSession) ValidateTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.ValidateTransaction(&_IAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x9c27706d.
+//
+// Solidity: function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_IAccount *IAccountTransactorSession) ValidateTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IAccount.Contract.ValidateTransaction(&_IAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}

--- a/u2u/contracts/eip712/IPaymaster.go
+++ b/u2u/contracts/eip712/IPaymaster.go
@@ -1,0 +1,240 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package eip712
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	u2u "github.com/unicornultrafoundation/go-u2u"
+	"github.com/unicornultrafoundation/go-u2u/accounts/abi"
+	"github.com/unicornultrafoundation/go-u2u/accounts/abi/bind"
+	"github.com/unicornultrafoundation/go-u2u/common"
+	"github.com/unicornultrafoundation/go-u2u/core/types"
+	"github.com/unicornultrafoundation/go-u2u/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = u2u.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+//type Transaction struct {
+//	TxType                 *big.Int
+//	From                   *big.Int
+//	To                     *big.Int
+//	GasLimit               *big.Int
+//	GasPerPubdataByteLimit *big.Int
+//	MaxFeePerGas           *big.Int
+//	MaxPriorityFeePerGas   *big.Int
+//	Paymaster              *big.Int
+//	Nonce                  *big.Int
+//	Value                  *big.Int
+//	Reserved               [4]*big.Int
+//	Data                   []byte
+//	Signature              []byte
+//	PaymasterInput         []byte
+//}
+
+// IPaymasterMetaData contains all meta data concerning the IPaymaster contract.
+var IPaymasterMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_context\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"internalType\":\"enumExecutionResult\",\"name\":\"_txResult\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"_maxRefundedGas\",\"type\":\"uint256\"}],\"name\":\"postTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"validateAndPayForPaymasterTransaction\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magic\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"context\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
+}
+
+// IPaymasterABI is the input ABI used to generate the binding from.
+// Deprecated: Use IPaymasterMetaData.ABI instead.
+var IPaymasterABI = IPaymasterMetaData.ABI
+
+// IPaymaster is an auto generated Go binding around an Ethereum contract.
+type IPaymaster struct {
+	IPaymasterCaller     // Read-only binding to the contract
+	IPaymasterTransactor // Write-only binding to the contract
+	IPaymasterFilterer   // Log filterer for contract events
+}
+
+// IPaymasterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IPaymasterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IPaymasterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IPaymasterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IPaymasterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IPaymasterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IPaymasterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IPaymasterSession struct {
+	Contract     *IPaymaster       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IPaymasterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IPaymasterCallerSession struct {
+	Contract *IPaymasterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// IPaymasterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IPaymasterTransactorSession struct {
+	Contract     *IPaymasterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// IPaymasterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IPaymasterRaw struct {
+	Contract *IPaymaster // Generic contract binding to access the raw methods on
+}
+
+// IPaymasterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IPaymasterCallerRaw struct {
+	Contract *IPaymasterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IPaymasterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IPaymasterTransactorRaw struct {
+	Contract *IPaymasterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIPaymaster creates a new instance of IPaymaster, bound to a specific deployed contract.
+func NewIPaymaster(address common.Address, backend bind.ContractBackend) (*IPaymaster, error) {
+	contract, err := bindIPaymaster(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IPaymaster{IPaymasterCaller: IPaymasterCaller{contract: contract}, IPaymasterTransactor: IPaymasterTransactor{contract: contract}, IPaymasterFilterer: IPaymasterFilterer{contract: contract}}, nil
+}
+
+// NewIPaymasterCaller creates a new read-only instance of IPaymaster, bound to a specific deployed contract.
+func NewIPaymasterCaller(address common.Address, caller bind.ContractCaller) (*IPaymasterCaller, error) {
+	contract, err := bindIPaymaster(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IPaymasterCaller{contract: contract}, nil
+}
+
+// NewIPaymasterTransactor creates a new write-only instance of IPaymaster, bound to a specific deployed contract.
+func NewIPaymasterTransactor(address common.Address, transactor bind.ContractTransactor) (*IPaymasterTransactor, error) {
+	contract, err := bindIPaymaster(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IPaymasterTransactor{contract: contract}, nil
+}
+
+// NewIPaymasterFilterer creates a new log filterer instance of IPaymaster, bound to a specific deployed contract.
+func NewIPaymasterFilterer(address common.Address, filterer bind.ContractFilterer) (*IPaymasterFilterer, error) {
+	contract, err := bindIPaymaster(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IPaymasterFilterer{contract: contract}, nil
+}
+
+// bindIPaymaster binds a generic wrapper to an already deployed contract.
+func bindIPaymaster(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(IPaymasterABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IPaymaster *IPaymasterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IPaymaster.Contract.IPaymasterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IPaymaster *IPaymasterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IPaymaster.Contract.IPaymasterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IPaymaster *IPaymasterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IPaymaster.Contract.IPaymasterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IPaymaster *IPaymasterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IPaymaster.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IPaymaster *IPaymasterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IPaymaster.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IPaymaster *IPaymasterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IPaymaster.Contract.contract.Transact(opts, method, params...)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x9f3cb0b0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction, bytes32 _txHash, bytes32 _suggestedSignedHash, uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_IPaymaster *IPaymasterTransactor) PostTransaction(opts *bind.TransactOpts, _context []byte, _transaction Transaction, _txHash [32]byte, _suggestedSignedHash [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _IPaymaster.contract.Transact(opts, "postTransaction", _context, _transaction, _txHash, _suggestedSignedHash, _txResult, _maxRefundedGas)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x9f3cb0b0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction, bytes32 _txHash, bytes32 _suggestedSignedHash, uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_IPaymaster *IPaymasterSession) PostTransaction(_context []byte, _transaction Transaction, _txHash [32]byte, _suggestedSignedHash [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _IPaymaster.Contract.PostTransaction(&_IPaymaster.TransactOpts, _context, _transaction, _txHash, _suggestedSignedHash, _txResult, _maxRefundedGas)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x9f3cb0b0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction, bytes32 _txHash, bytes32 _suggestedSignedHash, uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_IPaymaster *IPaymasterTransactorSession) PostTransaction(_context []byte, _transaction Transaction, _txHash [32]byte, _suggestedSignedHash [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _IPaymaster.Contract.PostTransaction(&_IPaymaster.TransactOpts, _context, _transaction, _txHash, _suggestedSignedHash, _txResult, _maxRefundedGas)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0xb12b0e2b.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns(bytes4 magic, bytes context)
+func (_IPaymaster *IPaymasterTransactor) ValidateAndPayForPaymasterTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IPaymaster.contract.Transact(opts, "validateAndPayForPaymasterTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0xb12b0e2b.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns(bytes4 magic, bytes context)
+func (_IPaymaster *IPaymasterSession) ValidateAndPayForPaymasterTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IPaymaster.Contract.ValidateAndPayForPaymasterTransaction(&_IPaymaster.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0xb12b0e2b.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes) _transaction) payable returns(bytes4 magic, bytes context)
+func (_IPaymaster *IPaymasterTransactorSession) ValidateAndPayForPaymasterTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _IPaymaster.Contract.ValidateAndPayForPaymasterTransaction(&_IPaymaster.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

- References: This PR refer to issue number no https://github.com/unicornultrafoundation/go-u2u/issues/91
- Checklist:
- [X] Define `EIP712TxType`
- [X] Define a hard fork checkpoint, signer and verifier to enable `EIP712TxType` and the AA flow  
- [X] Add Go binding of EIP-712 necessary interfaces