### PR TITLE
Improve transaction validation

### DIFF
--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -84,4 +84,11 @@ var (
 
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")
+
+	// ErrAccountLimitExceeded is returned if a transaction would exceed the number
+	// allowed by a pool for a single account.
+	ErrAccountLimitExceeded = errors.New("account limit exceeded")
+
+	// ErrInvalidPaymasterParams is returned if the paymaster params is malformed.
+	ErrInvalidPaymasterParams = errors.New("invalid paymaster params")
 )

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -251,17 +251,19 @@ type txList struct {
 	strict bool         // Whether nonces are strictly continuous or not
 	txs    *txSortedMap // Heap indexed sorted hash map of the transactions
 
-	costcap *big.Int // Price of the highest costing transaction (reset only if exceeds balance)
-	gascap  uint64   // Gas limit of the highest spending transaction (reset only if exceeds block limit)
+	costcap   *big.Int // Price of the highest costing transaction (reset only if exceeds balance)
+	gascap    uint64   // Gas limit of the highest spending transaction (reset only if exceeds block limit)
+	totalcost *big.Int // Total cost of all transactions in the list
 }
 
 // newTxList create a new transaction list for maintaining nonce-indexable fast,
 // gapped, sortable transaction lists.
 func newTxList(strict bool) *txList {
 	return &txList{
-		strict:  strict,
-		txs:     newTxSortedMap(),
-		costcap: new(big.Int),
+		strict:    strict,
+		txs:       newTxSortedMap(),
+		costcap:   new(big.Int),
+		totalcost: new(big.Int),
 	}
 }
 
@@ -299,7 +301,11 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
 			return false, nil
 		}
+		// Old is being replaced, subtract old cost
+		l.subTotalCost([]*types.Transaction{old})
 	}
+	// Add new tx cost to totalcost
+	l.totalcost.Add(l.totalcost, tx.Cost())
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
 	if cost := tx.Cost(); l.costcap.Cmp(cost) < 0 {
@@ -315,7 +321,9 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 // provided threshold. Every removed transaction is returned for any post-removal
 // maintenance.
 func (l *txList) Forward(threshold uint64) types.Transactions {
-	return l.txs.Forward(threshold)
+	txs := l.txs.Forward(threshold)
+	l.subTotalCost(txs)
+	return txs
 }
 
 // Filter removes all transactions from the list with a cost or gas limit higher
@@ -354,6 +362,9 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions
 		}
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
 	}
+	// Reset total cost
+	l.subTotalCost(removed)
+	l.subTotalCost(invalids)
 	l.txs.reheap()
 	return removed, invalids
 }
@@ -361,7 +372,9 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions
 // Cap places a hard limit on the number of items, returning all transactions
 // exceeding that limit.
 func (l *txList) Cap(threshold int) types.Transactions {
-	return l.txs.Cap(threshold)
+	txs := l.txs.Cap(threshold)
+	l.subTotalCost(txs)
+	return txs
 }
 
 // Remove deletes a transaction from the maintained list, returning whether the
@@ -373,9 +386,12 @@ func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
 	if removed := l.txs.Remove(nonce); !removed {
 		return false, nil
 	}
+	l.subTotalCost([]*types.Transaction{tx})
 	// In strict mode, filter out non-executable transactions
 	if l.strict {
-		return true, l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > nonce })
+		txs := l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > nonce })
+		l.subTotalCost(txs)
+		return true, txs
 	}
 	return true, nil
 }
@@ -388,7 +404,9 @@ func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
 // prevent getting into and invalid state. This is not something that should ever
 // happen but better to be self correcting than failing!
 func (l *txList) Ready(start uint64) types.Transactions {
-	return l.txs.Ready(start)
+	txs := l.txs.Ready(start)
+	l.subTotalCost(txs)
+	return txs
 }
 
 // Len returns the length of the transaction list.
@@ -412,6 +430,14 @@ func (l *txList) Flatten() types.Transactions {
 // transaction with the highest nonce
 func (l *txList) LastElement() *types.Transaction {
 	return l.txs.LastElement()
+}
+
+// subTotalCost subtracts the cost of the given transactions from the
+// total cost of all transactions.
+func (l *txList) subTotalCost(txs []*types.Transaction) {
+	for _, tx := range txs {
+		l.totalcost.Sub(l.totalcost, tx.Cost())
+	}
 }
 
 // priceHeap is a heap.Interface implementation over transactions for retrieving

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1245,6 +1245,15 @@ func (pool *TxPool) reset(oldHead, newHead *EvmHeader) {
 					"old", oldHead.Hash, "oldnum", oldNum, "new", newHead.Hash, "newnum", newNum)
 				// We still need to update the current state s.th. the lost transactions can be readded by the user
 			} else {
+				if add == nil {
+					// if the new head is nil, it means that something happened between
+					// the firing of newhead-event and _now_: most likely a
+					// reorg caused by sync-reversion or explicit sethead back to an
+					// earlier block.
+					log.Warn("Transaction pool reset with missing new head", "number", newHead.Number, "hash", newHead.Hash)
+					return
+				}
+				var discarded, included types.Transactions
 				for rem.NumberU64() > add.NumberU64() {
 					discarded = append(discarded, rem.Transactions...)
 					if rem = pool.chain.GetBlock(rem.ParentHash, rem.NumberU64()-1); rem == nil {

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -1241,20 +1241,20 @@ func TestTransactionAllowedTxSize(t *testing.T) {
 	dataSize := txMaxSize - baseSize
 
 	// Try adding a transaction with maximal allowed size
-	tx := pricedDataTransaction(0, pool.currentMaxGas, big.NewInt(1), key, dataSize)
+	tx := pricedDataTransaction(0, pool.currentMaxGas.Load(), big.NewInt(1), key, dataSize)
 	if err := pool.addRemoteSync(tx); err != nil {
 		t.Fatalf("failed to add transaction of size %d, close to maximal: %v", int(tx.Size()), err)
 	}
 	// Try adding a transaction with random allowed size
-	if err := pool.addRemoteSync(pricedDataTransaction(1, pool.currentMaxGas, big.NewInt(1), key, uint64(rand.Intn(int(dataSize))))); err != nil {
+	if err := pool.addRemoteSync(pricedDataTransaction(1, pool.currentMaxGas.Load(), big.NewInt(1), key, uint64(rand.Intn(int(dataSize))))); err != nil {
 		t.Fatalf("failed to add transaction of random allowed size: %v", err)
 	}
 	// Try adding a transaction of minimal not allowed size
-	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas, big.NewInt(1), key, txMaxSize)); err == nil {
+	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas.Load(), big.NewInt(1), key, txMaxSize)); err == nil {
 		t.Fatalf("expected rejection on slightly oversize transaction")
 	}
 	// Try adding a transaction of random not allowed size
-	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas, big.NewInt(1), key, dataSize+1+uint64(rand.Intn(10*txMaxSize)))); err == nil {
+	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas.Load(), big.NewInt(1), key, dataSize+1+uint64(rand.Intn(10*txMaxSize)))); err == nil {
 		t.Fatalf("expected rejection on oversize transaction")
 	}
 	// Run some sanity checks on the pool internals

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -307,28 +307,35 @@ func TestInvalidTransactions(t *testing.T) {
 	tx := transaction(0, 100, key)
 	from, _ := deriveSender(tx)
 
+	// Intrinsic gas too low
 	testAddBalance(pool, from, big.NewInt(1))
-	if err := pool.AddRemote(tx); !errors.Is(err, ErrInsufficientFunds) {
-		t.Error("expected", ErrInsufficientFunds)
+	if err, want := pool.AddRemote(tx), ErrIntrinsicGas; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
 	}
 
 	balance := new(big.Int).Add(tx.Value(), new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice()))
 	testAddBalance(pool, from, balance)
-	if err := pool.AddRemote(tx); !errors.Is(err, ErrIntrinsicGas) {
-		t.Error("expected", ErrIntrinsicGas, "got", err)
+	if err, want := pool.AddRemote(tx), ErrIntrinsicGas; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
+	}
+
+	// Insufficient funds
+	tx = transaction(0, 10000000, key)
+	if err, want := pool.AddRemote(tx), ErrInsufficientFunds; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
 	}
 
 	testSetNonce(pool, from, 1)
 	testAddBalance(pool, from, big.NewInt(0xffffffffffffff))
 	tx = transaction(0, 100000, key)
-	if err := pool.AddRemote(tx); !errors.Is(err, ErrNonceTooLow) {
-		t.Error("expected", ErrNonceTooLow)
+	if err, want := pool.AddRemote(tx), ErrNonceTooLow; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
 	}
 
 	tx = transaction(1, 100000, key)
 	pool.gasPrice = big.NewInt(1000)
-	if err := pool.AddRemote(tx); err != ErrUnderpriced {
-		t.Error("expected", ErrUnderpriced, "got", err)
+	if err, want := pool.AddRemote(tx), ErrUnderpriced; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
 	}
 	if err := pool.AddLocal(tx); err != nil {
 		t.Error("expected", nil, "got", err)
@@ -1129,7 +1136,7 @@ func TestTransactionPendingLimiting(t *testing.T) {
 	defer pool.Stop()
 
 	account := crypto.PubkeyToAddress(key.PublicKey)
-	testAddBalance(pool, account, big.NewInt(1000000))
+	testAddBalance(pool, account, big.NewInt(1000000000000))
 
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsNotify, testTxPoolConfig.AccountQueue+5)
@@ -1418,13 +1425,13 @@ func TestTransactionPoolRepricing(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Check that we can't add the old transactions back
-	if err := pool.AddRemote(pricedTransaction(1, 100000, big.NewInt(1), keys[0])); err != ErrUnderpriced {
+	if err := pool.AddRemote(pricedTransaction(1, 100000, big.NewInt(1), keys[0])); !errors.Is(err, ErrUnderpriced) {
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
-	if err := pool.AddRemote(pricedTransaction(0, 100000, big.NewInt(1), keys[1])); err != ErrUnderpriced {
+	if err := pool.AddRemote(pricedTransaction(0, 100000, big.NewInt(1), keys[1])); !errors.Is(err, ErrUnderpriced) {
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
-	if err := pool.AddRemote(pricedTransaction(2, 100000, big.NewInt(1), keys[2])); err != ErrUnderpriced {
+	if err := pool.AddRemote(pricedTransaction(2, 100000, big.NewInt(1), keys[2])); !errors.Is(err, ErrUnderpriced) {
 		t.Fatalf("adding underpriced queued transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
 	if err := validateEvents(events, 0); err != nil {
@@ -1540,15 +1547,15 @@ func TestTransactionPoolRepricingDynamicFee(t *testing.T) {
 	}
 	// Check that we can't add the old transactions back
 	tx := pricedTransaction(1, 100000, big.NewInt(1), keys[0])
-	if err := pool.AddRemote(tx); err != ErrUnderpriced {
+	if err := pool.AddRemote(tx); !errors.Is(err, ErrUnderpriced) {
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
 	tx = dynamicFeeTx(0, 100000, big.NewInt(2), big.NewInt(1), keys[1])
-	if err := pool.AddRemote(tx); err != ErrUnderpriced {
+	if err := pool.AddRemote(tx); !errors.Is(err, ErrUnderpriced) {
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
 	tx = dynamicFeeTx(2, 100000, big.NewInt(1), big.NewInt(1), keys[2])
-	if err := pool.AddRemote(tx); err != ErrUnderpriced {
+	if err := pool.AddRemote(tx); !errors.Is(err, ErrUnderpriced) {
 		t.Fatalf("adding underpriced queued transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
 	if err := validateEvents(events, 0); err != nil {
@@ -1608,7 +1615,7 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 	keys := make([]*ecdsa.PrivateKey, 3)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
-		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000*1000000))
+		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(100000*1000000))
 	}
 	// Create transaction (both pending and queued) with a linearly growing gasprice
 	for i := uint64(0); i < 500; i++ {

--- a/evmcore/validation.go
+++ b/evmcore/validation.go
@@ -1,0 +1,188 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package evmcore
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/unicornultrafoundation/go-u2u/common"
+	"github.com/unicornultrafoundation/go-u2u/core/state"
+	"github.com/unicornultrafoundation/go-u2u/core/types"
+	"github.com/unicornultrafoundation/go-u2u/log"
+	"github.com/unicornultrafoundation/go-u2u/params"
+)
+
+// ValidationOptions define certain differences between transaction validation
+// across the different pools without having to duplicate those checks.
+type ValidationOptions struct {
+	Config *params.ChainConfig // Chain configuration to selectively validate based on current fork rules
+
+	Local        bool
+	Accept       uint8    // Bitmap of transaction types that should be accepted for the calling pool
+	MaxSize      uint64   // Maximum size of a transaction that the caller can meaningfully handle
+	MinTip       *big.Int // Minimum gas tip needed to allow a transaction into the caller pool
+	MinGasPrice  *big.Int // The current hard lower bound for gas price required by chain
+	PoolGasPrice *big.Int
+}
+
+// ValidateTransaction is a helper method to check whether a transaction is valid
+// according to the consensus rules, but does not check state-dependent validation
+// (balance, nonce, etc).
+//
+// This check is public to allow different transaction pools to check the basic
+// rules without duplicating code and running the risk of missed updates.
+func ValidateTransaction(tx *types.Transaction, head *EvmHeader, signer types.Signer, opts *ValidationOptions) error {
+	// Ensure transactions not implemented by the calling pool are rejected
+	if opts.Accept&(1<<tx.Type()) == 0 {
+		return fmt.Errorf("%w: tx type %v not supported by this pool", ErrTxTypeNotSupported, tx.Type())
+	}
+	// Before performing any expensive validations, sanity check that the tx is
+	// smaller than the maximum limit the pool can meaningfully handle
+	if uint64(tx.Size()) > opts.MaxSize {
+		return fmt.Errorf("%w: transaction size %v, limit %v", ErrOversizedData, tx.Size(), opts.MaxSize)
+	}
+	// Ensure only transactions that have been enabled are accepted
+	if !opts.Config.IsBerlin(head.Number) && tx.Type() != types.LegacyTxType {
+		return fmt.Errorf("%w: type %d rejected, pool not yet in Berlin", ErrTxTypeNotSupported, tx.Type())
+	}
+	if !opts.Config.IsLondon(head.Number) && tx.Type() == types.DynamicFeeTxType {
+		return fmt.Errorf("%w: type %d rejected, pool not yet in London", ErrTxTypeNotSupported, tx.Type())
+	}
+	// Transactions can't be negative. This may never happen using RLP decoded
+	// transactions but may occur for transactions created using the RPC.
+	if tx.Value().Sign() < 0 {
+		return ErrNegativeValue
+	}
+	// Ensure the transaction doesn't exceed the current block limit gas
+	if head.GasLimit < tx.Gas() {
+		return ErrGasLimit
+	}
+	// Sanity check for extremely large numbers (supported by RLP or RPC)
+	if tx.GasFeeCap().BitLen() > 256 {
+		return ErrFeeCapVeryHigh
+	}
+	if tx.GasTipCap().BitLen() > 256 {
+		return ErrTipVeryHigh
+	}
+	// Ensure gasFeeCap is greater than or equal to gasTipCap
+	if tx.GasFeeCapIntCmp(tx.GasTipCap()) < 0 {
+		return ErrTipAboveFeeCap
+	}
+	// Ensure the gasprice is high enough to cover the requirement of the calling pool with U2U-specific hard bounds
+	if !opts.Local && tx.GasTipCapIntCmp(opts.PoolGasPrice) < 0 {
+		return fmt.Errorf("%w: gas tip cap %v, minimum needed %v", ErrUnderpriced, tx.GasTipCap(), opts.PoolGasPrice)
+	}
+	effectiveGasPrice := new(big.Int).Add(opts.MinTip, opts.MinGasPrice)
+	if tx.GasFeeCapIntCmp(effectiveGasPrice) < 0 {
+		return fmt.Errorf("%w: gas fee cap %v, minimum needed %v", ErrUnderpriced, tx.GasFeeCap(), effectiveGasPrice)
+	}
+	// Make sure the transaction is signed properly
+	if _, err := types.Sender(signer, tx); err != nil {
+		return ErrInvalidSender
+	}
+	// Ensure the transaction has more gas than the bare minimum needed to cover
+	// the transaction metadata
+	intrGas, err := IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil)
+	if err != nil {
+		return err
+	}
+	if tx.Gas() < intrGas {
+		return fmt.Errorf("%w: gas %v, minimum needed %v", ErrIntrinsicGas, tx.Gas(), intrGas)
+	}
+	return nil
+}
+
+// ValidationOptionsWithState define certain differences between stateful transaction
+// validation across the different pools without having to duplicate those checks.
+type ValidationOptionsWithState struct {
+	State *state.StateDB // State database to check nonces and balances against
+
+	// FirstNonceGap is an optional callback to retrieve the first nonce gap in
+	// the list of pooled transactions of a specific account. If this method is
+	// set, nonce gaps will be checked and forbidden. If this method is not set,
+	// nonce gaps will be ignored and permitted.
+	FirstNonceGap func(addr common.Address) uint64
+
+	// UsedAndLeftSlots is a mandatory callback to retrieve the number of tx slots
+	// used and the number still permitted for an account. New transactions will
+	// be rejected once the number of remaining slots reaches zero.
+	UsedAndLeftSlots func(addr common.Address) (int, int)
+
+	// ExistingExpenditure is a mandatory callback to retrieve the cumulative
+	// cost of the already pooled transactions to check for overdrafts.
+	ExistingExpenditure func(addr common.Address) *big.Int
+
+	// ExistingCost is a mandatory callback to retrieve an already pooled
+	// transaction's cost with the given nonce to check for overdrafts.
+	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+}
+
+// ValidateTransactionWithState is a helper method to check whether a transaction
+// is valid according to the pool's internal state checks (balance, nonce, gaps).
+//
+// This check is public to allow different transaction pools to check the stateful
+// rules without duplicating code and running the risk of missed updates.
+func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, opts *ValidationOptionsWithState) error {
+	// Ensure the transaction adheres to nonce ordering
+	from, err := signer.Sender(tx) // already validated (and cached), but cleaner to check
+	if err != nil {
+		log.Error("Transaction sender recovery failed", "err", err)
+		return err
+	}
+	next := opts.State.GetNonce(from)
+	if next > tx.Nonce() {
+		return fmt.Errorf("%w: next nonce %v, tx nonce %v", ErrNonceTooLow, next, tx.Nonce())
+	}
+	// Ensure the transaction doesn't produce a nonce gap in pools that do not
+	// support arbitrary orderings
+	if opts.FirstNonceGap != nil {
+		if gap := opts.FirstNonceGap(from); gap < tx.Nonce() {
+			return fmt.Errorf("%w: tx nonce %v, gapped nonce %v", ErrNonceTooHigh, tx.Nonce(), gap)
+		}
+	}
+	// Ensure the transactor has enough funds to cover the transaction costs
+	var (
+		balance = opts.State.GetBalance(from)
+		cost    = tx.Cost()
+	)
+	if balance.Cmp(cost) < 0 {
+		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", ErrInsufficientFunds, balance, cost, new(big.Int).Sub(cost, balance))
+	}
+	// Ensure the transactor has enough funds to cover for replacements or nonce
+	// expansions without overdrafts
+	spent := opts.ExistingExpenditure(from)
+	if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
+		bump := new(big.Int).Sub(cost, prev)
+		need := new(big.Int).Add(spent, bump)
+		if balance.Cmp(need) < 0 {
+			return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v", ErrInsufficientFunds, balance, spent, bump, new(big.Int).Sub(need, balance))
+		}
+	} else {
+		need := new(big.Int).Add(spent, cost)
+		if balance.Cmp(need) < 0 {
+			return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v", ErrInsufficientFunds, balance, spent, cost, new(big.Int).Sub(need, balance))
+		}
+		// Transaction takes a new nonce value out of the pool. Ensure it doesn't
+		// overflow the number of permitted transactions from a single account
+		// (i.e. max cancellable via out-of-bound transaction).
+		if used, left := opts.UsedAndLeftSlots(from); left <= 0 {
+			return fmt.Errorf("%w: pooled %d txs", ErrAccountLimitExceeded, used)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

- References: This PR refer to issue number no https://github.com/unicornultrafoundation/go-u2u/issues/102
- Checklist:
- [X] Separate low cost transaction validation step and heavy state-related one
- [X] Calculate the `totalcost` of all transactions belong to an address, for ease of stateful validation
- [X] Move some validation rules outside of mutex
- [X] When we try to reorg the `txpool` to a `newHead` and that `newHead` seems to be missing from the db. We only have the header but not the full block. This PR checks to not reset `txpool` to the `newHead` if missing to avoid panicking