### PR TITLE
Remove fjl/memzise dependency and fix unit tests

### DIFF
--- a/cmd/u2u/launcher/launcher.go
+++ b/cmd/u2u/launcher/launcher.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/unicornultrafoundation/go-helios/native/idx"
 	"gopkg.in/urfave/cli.v1"
 
+	"github.com/unicornultrafoundation/go-helios/native/idx"
 	"github.com/unicornultrafoundation/go-u2u/accounts"
 	"github.com/unicornultrafoundation/go-u2u/accounts/keystore"
 	"github.com/unicornultrafoundation/go-u2u/cmd/u2u/launcher/monitoring"
@@ -387,8 +387,6 @@ func makeConfigNode(ctx *cli.Context, cfg *node.Config) *node.Node {
 // startNode boots up the system node and all registered protocols, after which
 // it unlocks any requested accounts, and starts the RPC/IPC interfaces.
 func startNode(ctx *cli.Context, stack *node.Node) {
-	debug.Memsize.Add("node", stack)
-
 	// Start up the node itself
 	utils.StartNode(ctx, stack)
 

--- a/cmd/u2u/launcher/txtracer_test.go
+++ b/cmd/u2u/launcher/txtracer_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/unicornultrafoundation/go-u2u/evmcore/txtracer"
 )
 
@@ -22,7 +23,8 @@ func TestTxTracing(t *testing.T) {
 	wsport := strconv.Itoa(trulyRandInt(10000, 65536))
 	cliNode := exec(t,
 		"--fakenet", "1/1", "--enabletxtracer", "--port", "0", "--maxpeers", "0", "--nodiscover", "--nat", "none",
-		"--ws", "--ws.port", wsport, "--http", "--http.api", "eth,web3,net,txpool,trace", "--http.port", port, "--allow-insecure-unlock")
+		"--ws", "--ws.port", wsport, "--http", "--http.api", "eth,web3,net,txpool,trace", "--http.port",
+		port, "--allow-insecure-unlock", "--cache", "8192")
 
 	// Wait for node to start
 	endpoint := "ws://127.0.0.1:" + wsport

--- a/debug/flags.go
+++ b/debug/flags.go
@@ -24,16 +24,14 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/fjl/memsize/memsizeui"
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
+	"gopkg.in/urfave/cli.v1"
+
 	"github.com/unicornultrafoundation/go-u2u/log"
 	"github.com/unicornultrafoundation/go-u2u/metrics"
 	"github.com/unicornultrafoundation/go-u2u/metrics/exp"
-	"gopkg.in/urfave/cli.v1"
 )
-
-var Memsize memsizeui.Handler
 
 var (
 	verbosityFlag = cli.IntFlag{
@@ -196,7 +194,6 @@ func StartPProf(address string, withMetrics bool) {
 	if withMetrics {
 		exp.Exp(metrics.DefaultRegistry)
 	}
-	http.Handle("/memsize/", http.StripPrefix("/memsize", &Memsize))
 	log.Info("Starting pprof server", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
 	go func() {
 		if err := http.ListenAndServe(address, nil); err != nil {

--- a/gossip/filters/api_test.go
+++ b/gossip/filters/api_test.go
@@ -56,7 +56,7 @@ func TestUnmarshalJSONNewFilterArgs(t *testing.T) {
 
 	// from, to block number
 	var test1 FilterCriteria
-	vector := fmt.Sprintf(`{"fromBlock":"0x%x","toBlock":"0x%x"}`, fromBlock, toBlock)
+	vector := fmt.Sprintf(`{"fromBlock":"%v","toBlock":"%v"}`, fromBlock, toBlock)
 	if err := json.Unmarshal([]byte(vector), &test1); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/fjl/memsize/memsizeui"
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/unicornultrafoundation/go-u2u/log"
@@ -32,8 +31,6 @@ import (
 	"github.com/unicornultrafoundation/go-u2u/metrics/exp"
 	"gopkg.in/urfave/cli.v1"
 )
-
-var Memsize memsizeui.Handler
 
 var (
 	verbosityFlag = cli.IntFlag{
@@ -256,7 +253,6 @@ func StartPProf(address string, withMetrics bool) {
 	if withMetrics {
 		exp.Exp(metrics.DefaultRegistry)
 	}
-	http.Handle("/memsize/", http.StripPrefix("/memsize", &Memsize))
 	log.Info("Starting pprof server", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
 	go func() {
 		if err := http.ListenAndServe(address, nil); err != nil {

--- a/monitoring/prometheus/handler.go
+++ b/monitoring/prometheus/handler.go
@@ -34,8 +34,6 @@ func PrometheusListener(endpoint string, reg metrics.Registry) {
 }
 
 func collect(name string, metric interface{}) {
-	logger.Info("metric to prometheus", "metric", name)
-
 	collector, ok := convertToPrometheusMetric(name, metric)
 	if !ok {
 		return


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

As of Go 1.23, `memsize` no longer works because of a restriction added by the Go toolchain. The Go 1.23 compiler no longer allows access to runtime symbols via `go:linkname`, which prevents `memsize` from accessing the Stop-the-World functionality of the Go runtime.

The only reason for this library use was a Pprof endpoint providing an information about the amount of memory consumed by the `node.Node` structure. The usability of the endpoint is questionable and its removal seems to be the simplest way of restoring compatibility with the latest Go toolchain.

This PR also minor fix some unit tests from last merges.