### PR TITLE
Fix issue N5: Implicit memory aliasing in for loop

### DIFF
--- a/cmd/u2u/launcher/accountcmd.go
+++ b/cmd/u2u/launcher/accountcmd.go
@@ -203,6 +203,7 @@ func accountList(ctx *cli.Context) error {
 	var index int
 	for _, wallet := range stack.AccountManager().Wallets() {
 		for _, account := range wallet.Accounts() {
+			account := account
 			fmt.Printf("Account #%d: {%x} %s\n", index, account.Address, &account.URL)
 			index++
 		}

--- a/cmd/u2u/launcher/accountcmd.go
+++ b/cmd/u2u/launcher/accountcmd.go
@@ -277,6 +277,7 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 	fmt.Println("Testing your passphrase against all of them...")
 	var match *accounts.Account
 	for _, a := range err.Matches {
+		a := a
 		if err := ks.Unlock(a, auth); err == nil {
 			match = &a
 			break

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -484,6 +484,7 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 func (f *freezer) repair() error {
 	min := uint64(math.MaxUint64)
 	for _, table := range f.tables {
+		table := table
 		items := atomic.LoadUint64(&table.items)
 		if min > items {
 			min = items

--- a/ethapi/tx_tracer.go
+++ b/ethapi/tx_tracer.go
@@ -531,6 +531,7 @@ func (s *PublicTxTraceAPI) Filter(ctx context.Context, args FilterArgs) (*[]txtr
 						}
 						if addTrace {
 							if traceCount >= args.After {
+								trace := trace
 								callTrace.AddTrace(&trace)
 								traceAdded++
 							}

--- a/evmcore/txtracer/tx_tracer.go
+++ b/evmcore/txtracer/tx_tracer.go
@@ -409,6 +409,7 @@ func (callTrace *CallTrace) AddTrace(blockTrace *ActionTrace) {
 // AddTraces Append traces to call trace list
 func (callTrace *CallTrace) AddTraces(traces *[]ActionTrace, traceIndex *[]hexutil.Uint) {
 	for _, trace := range *traces {
+		trace := trace
 		if traceIndex == nil || equalContent(traceIndex, trace.TraceAddress) {
 			callTrace.AddTrace(&trace)
 		}

--- a/gossip/filters/api.go
+++ b/gossip/filters/api.go
@@ -280,6 +280,7 @@ func (api *PublicFilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc
 			select {
 			case logs := <-matchedLogs:
 				for _, log := range logs {
+					log := log
 					_ = notifier.Notify(rpcSub.ID, &log)
 				}
 			case <-rpcSub.Err(): // client send an unsubscribe request

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -737,6 +737,7 @@ func (t *UDPv4) handleFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID eno
 	var sent bool
 	for _, n := range closest {
 		// Don't advertise the private nodes
+		n := n
 		if len(t.privateNodes) > 0 && containsEnode(t.privateNodes, &n.Node) {
 			continue
 		}

--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -21,9 +21,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"html"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/julienschmidt/httprouter"
+
 	"github.com/unicornultrafoundation/go-u2u/event"
 	"github.com/unicornultrafoundation/go-u2u/p2p"
 	"github.com/unicornultrafoundation/go-u2u/p2p/enode"
@@ -101,7 +103,7 @@ type SubscribeOpts struct {
 // nodes and connections and filtering message events
 func (c *Client) SubscribeNetwork(events chan *Event, opts SubscribeOpts) (event.Subscription, error) {
 	url := fmt.Sprintf("%s/events?current=%t&filter=%s", c.URL, opts.Current, opts.Filter)
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +113,7 @@ func (c *Client) SubscribeNetwork(events chan *Event, opts SubscribeOpts) (event
 		return nil, err
 	}
 	if res.StatusCode != http.StatusOK {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		res.Body.Close()
 		return nil, fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
@@ -211,24 +213,24 @@ func (c *Client) RPCClient(ctx context.Context, nodeID string) (*rpc.Client, err
 	return rpc.DialWebsocket(ctx, fmt.Sprintf("%s/nodes/%s/rpc", baseURL, nodeID), "")
 }
 
-// Get performs a HTTP GET request decoding the resulting JSON response
+// Get performs an HTTP GET request decoding the resulting JSON response
 // into "out"
 func (c *Client) Get(path string, out interface{}) error {
-	return c.Send("GET", path, nil, out)
+	return c.Send(http.MethodGet, path, nil, out)
 }
 
-// Post performs a HTTP POST request sending "in" as the JSON body and
+// Post performs an HTTP POST request sending "in" as the JSON body and
 // decoding the resulting JSON response into "out"
 func (c *Client) Post(path string, in, out interface{}) error {
-	return c.Send("POST", path, in, out)
+	return c.Send(http.MethodPost, path, in, out)
 }
 
-// Delete performs a HTTP DELETE request
+// Delete performs an HTTP DELETE request
 func (c *Client) Delete(path string) error {
-	return c.Send("DELETE", path, nil, nil)
+	return c.Send(http.MethodDelete, path, nil, nil)
 }
 
-// Send performs a HTTP request, sending "in" as the JSON request body and
+// Send performs an HTTP request, sending "in" as the JSON request body and
 // decoding the JSON response into "out"
 func (c *Client) Send(method, path string, in, out interface{}) error {
 	var body []byte
@@ -251,7 +253,7 @@ func (c *Client) Send(method, path string, in, out interface{}) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
 	if out != nil {
@@ -336,7 +338,7 @@ func (s *Server) StartMocker(w http.ResponseWriter, req *http.Request) {
 	mockerType := req.FormValue("mocker-type")
 	mockerFn := LookupMocker(mockerType)
 	if mockerFn == nil {
-		http.Error(w, fmt.Sprintf("unknown mocker type %q", mockerType), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("unknown mocker type %q", html.EscapeString(mockerType)), http.StatusBadRequest)
 		return
 	}
 	nodeCount, err := strconv.Atoi(req.FormValue("node-count"))
@@ -364,9 +366,8 @@ func (s *Server) StopMocker(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// GetMockerList returns a list of available mockers
+// GetMockers returns a list of available mockers
 func (s *Server) GetMockers(w http.ResponseWriter, req *http.Request) {
-
 	list := GetMockerList()
 	s.JSON(w, http.StatusOK, list)
 }
@@ -434,13 +435,15 @@ func (s *Server) StreamNetworkEvents(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		for _, node := range snap.Nodes {
-			event := NewEvent(&node.Node)
+			n := node.Node
+			event := NewEvent(&n)
 			if err := writeEvent(event); err != nil {
 				writeErr(err)
 				return
 			}
 		}
 		for _, conn := range snap.Conns {
+			conn := conn
 			event := NewEvent(&conn)
 			if err := writeEvent(event); err != nil {
 				writeErr(err)
@@ -478,12 +481,12 @@ func (s *Server) StreamNetworkEvents(w http.ResponseWriter, req *http.Request) {
 func NewMsgFilters(filterParam string) (MsgFilters, error) {
 	filters := make(MsgFilters)
 	for _, filter := range strings.Split(filterParam, "-") {
-		protoCodes := strings.SplitN(filter, ":", 2)
-		if len(protoCodes) != 2 || protoCodes[0] == "" || protoCodes[1] == "" {
+		proto, codes, found := strings.Cut(filter, ":")
+		if !found || proto == "" || codes == "" {
 			return nil, fmt.Errorf("invalid message filter: %s", filter)
 		}
-		proto := protoCodes[0]
-		for _, code := range strings.Split(protoCodes[1], ",") {
+
+		for _, code := range strings.Split(codes, ",") {
 			if code == "*" || code == "-1" {
 				filters[MsgFilter{Proto: proto, Code: -1}] = struct{}{}
 				continue
@@ -559,7 +562,7 @@ func (s *Server) CreateNode(w http.ResponseWriter, req *http.Request) {
 	config := &adapters.NodeConfig{}
 
 	err := json.NewDecoder(req.Body).Decode(config)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

In some code snippets, implicit memory aliasing is used in the for loop, which may lead to potential concurrency issues or data inconsistency. To avoid this, a new variable can be created inside the loop to hold the value of the current iteration. By that, you ensure that each iteration receives an independent copy of the current variable, thus avoiding implicit memory aliasing problems.