### PR TITLE
Implement skeleton to handle basic sfc state logics (closes #140)

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -64,6 +64,11 @@ func BigToHash(b *big.Int) Hash { return BytesToHash(b.Bytes()) }
 // If b is larger than len(h), b will be cropped from the left.
 func HexToHash(s string) Hash { return BytesToHash(FromHex(s)) }
 
+// Cmp compares two hashes.
+func (h Hash) Cmp(other Hash) int {
+	return bytes.Compare(h[:], other[:])
+}
+
 // Bytes gets the byte representation of the underlying hash.
 func (h Hash) Bytes() []byte { return h[:] }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -547,6 +547,10 @@ func (s *stateObject) Nonce() uint64 {
 	return s.data.Nonce
 }
 
+func (s *stateObject) Root() common.Hash {
+	return s.data.Root
+}
+
 // Never called, but must be present to allow stateObject to be used
 // as a vm.Account interface that also satisfies the vm.ContractRef
 // interface. Interfaces are awesome.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -276,6 +276,16 @@ func (s *StateDB) GetNonce(addr common.Address) uint64 {
 	return 0
 }
 
+// GetStorageRoot retrieves the storage root from the given address or empty
+// if object not found.
+func (s *StateDB) GetStorageRoot(addr common.Address) common.Hash {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.Root()
+	}
+	return common.Hash{}
+}
+
 // TxIndex returns the current transaction index set by Prepare.
 func (s *StateDB) TxIndex() int {
 	return s.txIndex

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -46,6 +46,7 @@ type StateDB interface {
 	GetCommittedState(common.Address, common.Hash) common.Hash
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash)
+	GetStorageRoot(addr common.Address) common.Hash
 
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool

--- a/core/vm/metrics.go
+++ b/core/vm/metrics.go
@@ -4,8 +4,8 @@ import "github.com/unicornultrafoundation/go-u2u/metrics"
 
 var (
 	// execution time diff metrics
-	sfcDiffCallTimer         = metrics.NewRegisteredResettingTimer("sfc/diff/call", nil)
-	sfcDiffCallCodeTimer     = metrics.NewRegisteredResettingTimer("sfc/diff/callcode", nil)
-	sfcDiffDelegateCallTimer = metrics.NewRegisteredResettingTimer("sfc/diff/delegatecall", nil)
-	sfcDiffStaticCallTimer   = metrics.NewRegisteredResettingTimer("sfc/diff/staticcall", nil)
+	sfcDiffCallMeter         = metrics.GetOrRegisterMeter("sfc/diff/call", nil)
+	sfcDiffCallCodeMeter     = metrics.GetOrRegisterMeter("sfc/diff/callcode", nil)
+	sfcDiffDelegateCallMeter = metrics.GetOrRegisterMeter("sfc/diff/delegatecall", nil)
+	sfcDiffStaticCallMeter   = metrics.GetOrRegisterMeter("sfc/diff/staticcall", nil)
 )

--- a/core/vm/metrics.go
+++ b/core/vm/metrics.go
@@ -1,0 +1,10 @@
+package vm
+
+import "github.com/unicornultrafoundation/go-u2u/metrics"
+
+var (
+	sfcDiffCallTimer         = metrics.NewRegisteredResettingTimer("sfc/diff/call", nil)
+	sfcDiffCallCodeTimer     = metrics.NewRegisteredResettingTimer("sfc/diff/callcode", nil)
+	sfcDiffDelegateCallTimer = metrics.NewRegisteredResettingTimer("sfc/diff/delegatecall", nil)
+	sfcDiffStaticCallTimer   = metrics.NewRegisteredResettingTimer("sfc/diff/staticcall", nil)
+)

--- a/core/vm/metrics.go
+++ b/core/vm/metrics.go
@@ -3,6 +3,7 @@ package vm
 import "github.com/unicornultrafoundation/go-u2u/metrics"
 
 var (
+	// execution time diff metrics
 	sfcDiffCallTimer         = metrics.NewRegisteredResettingTimer("sfc/diff/call", nil)
 	sfcDiffCallCodeTimer     = metrics.NewRegisteredResettingTimer("sfc/diff/callcode", nil)
 	sfcDiffDelegateCallTimer = metrics.NewRegisteredResettingTimer("sfc/diff/delegatecall", nil)

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -52,6 +52,6 @@ type EVMProcessor interface {
 }
 
 type EVM interface {
-	Start(block iblockproc.BlockCtx, statedb *state.StateDB, reader evmcore.DummyChain,
+	Start(block iblockproc.BlockCtx, statedb *state.StateDB, sfcStatedb *state.StateDB, reader evmcore.DummyChain,
 		onNewLog func(*types.Log), net u2u.Rules, evmCfg *params.ChainConfig) EVMProcessor
 }

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -229,7 +229,7 @@ func consensusCallbackBeginBlockFn(
 				skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
 				// Finalize the progress of eventProcessor
 				bs = eventProcessor.Finalize(blockCtx, skipBlock) // TODO: refactor to not mutate the bs, it is unclear
-				{ // sort and merge MPs cheaters
+				{                                                 // sort and merge MPs cheaters
 					mpsCheaters := make(utypes.Cheaters, 0, len(mpsCheatersMap))
 					for vid := range mpsCheatersMap {
 						mpsCheaters = append(mpsCheaters, vid)

--- a/native/ibr/native_block_records.go
+++ b/native/ibr/native_block_records.go
@@ -16,6 +16,7 @@ type LlrBlockVote struct {
 	ReceiptsHash hash.Hash
 	Time         native.Timestamp
 	GasUsed      uint64
+	SfcStateRoot hash.Hash `rlp:"optional"`
 }
 
 type LlrFullBlockRecord struct {
@@ -45,5 +46,6 @@ func (br LlrFullBlockRecord) Hash() hash.Hash {
 		ReceiptsHash: native.CalcReceiptsHash(br.Receipts),
 		Time:         br.Time,
 		GasUsed:      br.GasUsed,
+		SfcStateRoot: br.SfcStateRoot,
 	}.Hash()
 }


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

### References
This PR refer to issue https://github.com/unicornultrafoundation/go-u2u/issues/140
### Description
The block/epoch producing, propagating and verifying for consensus don't require state roots checking. So in this PR we only implement the SFC execution flow with metrics and double check mechanism.
- [X] Implement SFC execution flow
- [X] Add metrics to compare execution time btw SFC precompiles and normal EVM flow
- [X] Validate the execution result btw SFC precompiles and normal EVM flow