### PR TITLE
Add metrics for txs added into txpool and into chain

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -121,6 +121,8 @@ var (
 	slotsGauge   = metrics.GetOrRegisterGauge("txpool/slots", nil)
 
 	reheapTimer = metrics.GetOrRegisterTimer("txpool/reheap", nil)
+
+	receivedTxsMeter = metrics.GetOrRegisterMeter("txpool/received", nil)
 )
 
 // TxStatus is the current status of a transaction as seen by the pool.
@@ -659,6 +661,10 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 		invalidTxMeter.Mark(1)
 		return false, err
 	}
+
+	// Mark a new received valid tx
+	receivedTxsMeter.Mark(1)
+
 	// If the transaction pool is full, discard underpriced transactions
 	if uint64(pool.all.Slots()+numSlots(tx)) > pool.config.GlobalSlots+pool.config.GlobalQueue {
 		// If the new transaction is underpriced, don't accept it

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -56,6 +56,8 @@ var (
 	blockExecutionTimer = metrics.GetOrRegisterTimer("chain/execution", nil)
 	blockWriteTimer     = metrics.GetOrRegisterTimer("chain/write", nil)
 	blockAgeGauge       = metrics.GetOrRegisterGauge("chain/block/age", nil)
+
+	processedTxsMeter = metrics.GetOrRegisterMeter("chain/txs/processed", nil)
 )
 
 type ExtendedTxPosition struct {
@@ -463,6 +465,7 @@ func consensusCallbackBeginBlockFn(
 						evmBlock.GasUsed, "txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), len(block.SkippedTxs)),
 						"age", utils.PrettyDuration(blockAge), "t", utils.PrettyDuration(now.Sub(start)))
 					blockAgeGauge.Update(int64(blockAge.Nanoseconds()))
+					processedTxsMeter.Mark(int64(len(evmBlock.Transactions)))
 				}
 				if confirmedEvents.Len() != 0 {
 					atomic.StoreUint32(blockBusyFlag, 1)


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

### Description
Add 2 transactions amount metrics:
- `chain_txs_processed` - the amout of txs in the chain (for on-chain txs/sec)
- `txpool_received` - the amount of txs added into the txpool (excluding invalid and already included ones) (for txpool txs/sec)
