### PR TITLE
Fix some data races in p2p & txpool packages

### DIFF
--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -21,6 +21,8 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/unicornultrafoundation/go-u2u/common"
@@ -504,9 +506,11 @@ func (h *priceHeap) Pop() interface{} {
 // better candidates for inclusion while in other cases (at the top of the baseFee peak)
 // the floating heap is better. When baseFee is decreasing they behave similarly.
 type txPricedList struct {
-	all              *txLookup // Pointer to the map of all transactions
-	urgent, floating priceHeap // Heaps of prices of all the stored **remote** transactions
-	stales           int       // Number of stale price points to (re-heap trigger)
+	stales atomic.Int64 // Number of stale price points to (re-heap trigger)
+
+	all              *txLookup  // Pointer to the map of all transactions
+	urgent, floating priceHeap  // Heaps of prices of all the stored **remote** transactions
+	reheapMu         sync.Mutex // Mutex asserts that only one routine is reheaping the list
 }
 
 const (
@@ -536,8 +540,8 @@ func (l *txPricedList) Put(tx *types.Transaction, local bool) {
 // the heap if a large enough ratio of transactions go stale.
 func (l *txPricedList) Removed(count int) {
 	// Bump the stale counter, but exit if still too low (< 25%)
-	l.stales += count
-	if l.stales <= (len(l.urgent.list)+len(l.floating.list))/4 {
+	stales := l.stales.Add(int64(count))
+	if int(stales) <= (len(l.urgent.list)+len(l.floating.list))/4 {
 		return
 	}
 	// Seems we've reached a critical number of stale transactions, reheap
@@ -561,7 +565,7 @@ func (l *txPricedList) underpricedFor(h *priceHeap, tx *types.Transaction) bool 
 	for len(h.list) > 0 {
 		head := h.list[0]
 		if l.all.GetRemote(head.Hash()) == nil { // Removed or migrated
-			l.stales--
+			l.stales.Add(-1)
 			heap.Pop(h)
 			continue
 		}
@@ -587,10 +591,10 @@ func (l *txPricedList) Discard(slots int, force bool) (types.Transactions, bool)
 			// Discard stale transactions if found during cleanup
 			tx := heap.Pop(&l.urgent).(*types.Transaction)
 			if l.all.GetRemote(tx.Hash()) == nil { // Removed or migrated
-				l.stales--
+				l.stales.Add(-1)
 				continue
 			}
-			// Non stale transaction found, move to floating heap
+			// Non-stale transaction found, move to floating heap
 			heap.Push(&l.floating, tx)
 		} else {
 			if len(l.floating.list) == 0 {
@@ -600,10 +604,10 @@ func (l *txPricedList) Discard(slots int, force bool) (types.Transactions, bool)
 			// Discard stale transactions if found during cleanup
 			tx := heap.Pop(&l.floating).(*types.Transaction)
 			if l.all.GetRemote(tx.Hash()) == nil { // Removed or migrated
-				l.stales--
+				l.stales.Add(-1)
 				continue
 			}
-			// Non stale transaction found, discard it
+			// Non-stale transaction found, discard it
 			drop = append(drop, tx)
 			slots -= numSlots(tx)
 		}
@@ -620,8 +624,10 @@ func (l *txPricedList) Discard(slots int, force bool) (types.Transactions, bool)
 
 // Reheap forcibly rebuilds the heap based on the current remote transaction set.
 func (l *txPricedList) Reheap() {
+	l.reheapMu.Lock()
+	defer l.reheapMu.Unlock()
 	start := time.Now()
-	l.stales = 0
+	l.stales.Store(0)
 	l.urgent.list = make([]*types.Transaction, 0, l.all.RemoteCount())
 	l.all.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
 		l.urgent.list = append(l.urgent.list, tx)

--- a/gossip/evmstore/evmpruner/pruner.go
+++ b/gossip/evmstore/evmpruner/pruner.go
@@ -33,11 +33,10 @@ import (
 	"github.com/unicornultrafoundation/go-u2u/core/state/snapshot"
 	"github.com/unicornultrafoundation/go-u2u/core/types"
 	"github.com/unicornultrafoundation/go-u2u/ethdb"
+	"github.com/unicornultrafoundation/go-u2u/gossip/evmstore"
 	"github.com/unicornultrafoundation/go-u2u/log"
 	"github.com/unicornultrafoundation/go-u2u/rlp"
 	"github.com/unicornultrafoundation/go-u2u/trie"
-
-	"github.com/unicornultrafoundation/go-u2u/gossip/evmstore"
 )
 
 const (

--- a/gossip/gasprice/gasprice_test.go
+++ b/gossip/gasprice/gasprice_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unicornultrafoundation/go-helios/native/idx"
 
 	"github.com/unicornultrafoundation/go-u2u/common"
 	"github.com/unicornultrafoundation/go-u2u/common/math"
 	"github.com/unicornultrafoundation/go-u2u/core/types"
-
-	"github.com/unicornultrafoundation/go-helios/native/idx"
 	"github.com/unicornultrafoundation/go-u2u/u2u"
 )
 

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -108,7 +108,7 @@ type dialScheduler struct {
 	// Everything below here belongs to loop and
 	// should only be accessed by code on the loop goroutine.
 	dialing   map[enode.ID]*dialTask // active tasks
-	peers     map[enode.ID]connFlag  // all connected peers
+	peers     map[enode.ID]struct{}  // all connected peers
 	dialPeers int                    // current number of dialed peers
 
 	// The static map tracks all static dial tasks. The subset of usable static dial tasks
@@ -168,7 +168,7 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 		setupFunc:   setupFunc,
 		dialing:     make(map[enode.ID]*dialTask),
 		static:      make(map[enode.ID]*dialTask),
-		peers:       make(map[enode.ID]connFlag),
+		peers:       make(map[enode.ID]struct{}),
 		doneCh:      make(chan *dialTask),
 		nodesIn:     make(chan *enode.Node),
 		addStaticCh: make(chan *enode.Node),
@@ -261,7 +261,7 @@ loop:
 				d.dialPeers++
 			}
 			id := c.node.ID()
-			d.peers[id] = c.flags
+			d.peers[id] = struct{}{}
 			// Remove from static pool because the node is now connected.
 			task := d.static[id]
 			if task != nil && task.staticPoolIndex >= 0 {

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -268,7 +268,7 @@ func (s *genIter) Node() *Node {
 }
 
 func (s *genIter) Close() {
-	s.index = ^uint32(0)
+	atomic.StoreUint32(&s.index, ^uint32(0))
 }
 
 func testNode(id, seq uint64) *Node {

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -129,6 +129,7 @@ func (b *SyncBloom) init(database ethdb.Iteratee) {
 func (b *SyncBloom) meter() {
 	// check every second
 	tick := time.NewTicker(1 * time.Second)
+	defer tick.Stop()
 	for {
 		select {
 		case <-tick.C:


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

### Description
- [X] Don't store flags in `d.peers` due to races. Storing in handshaked `conn` is enough
- [X] Fix races between `txPricedList.SetBaseFee()`, `txPricedList.Removed()` and `txPricedList.Reheap()` on who is allowed to reheap the list
- [X] Fix races between several methods in `txPricedList` on updating the txlist.stales counter
- [X] Fix races during testing between the `txpool.loop()` and reseting the txpool's blockchain between tests
- [X] Fix races during testing when updating `txpool.chain.gaslimit` from within a test