### PR TITLE
Add txpool reorg changes counter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
 
-
 jobs:
   build:
     name: Build
@@ -25,14 +24,3 @@ jobs:
           go-version: '1.23.4'
       - name: Test with the Go CLI
         run: go test --timeout 10m -coverprofile=coverage.out ./...
-      - uses: sonarsource/sonarqube-scan-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-     
-      # If you wish to fail your job when the Quality Gate is red, uncomment the
-      # following lines. This would typically be used to fail a deployment.
-      # - uses: sonarsource/sonarqube-quality-gate-action@master
-      #   timeout-minutes: 5
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -1,0 +1,1 @@
+package types

--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -1,1 +1,148 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/unicornultrafoundation/go-u2u/common"
+	"github.com/unicornultrafoundation/go-u2u/crypto"
+	"github.com/unicornultrafoundation/go-u2u/rlp"
+)
+
+type devnull struct{ len int }
+
+func (d *devnull) Write(p []byte) (int, error) {
+	d.len += len(p)
+	return len(p), nil
+}
+
+func BenchmarkEncodeRLP(b *testing.B) {
+	benchRLP(b, true)
+}
+
+func BenchmarkDecodeRLP(b *testing.B) {
+	benchRLP(b, false)
+}
+
+func benchRLP(b *testing.B, encode bool) {
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	to := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	signer := NewLondonSigner(big.NewInt(1337))
+	for _, tc := range []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			"legacy-header",
+			&Header{
+				Difficulty: big.NewInt(10000000000),
+				Number:     big.NewInt(1000),
+				GasLimit:   8_000_000,
+				GasUsed:    8_000_000,
+				Time:       555,
+				Extra:      make([]byte, 32),
+			},
+		},
+		{
+			"london-header",
+			&Header{
+				Difficulty: big.NewInt(10000000000),
+				Number:     big.NewInt(1000),
+				GasLimit:   8_000_000,
+				GasUsed:    8_000_000,
+				Time:       555,
+				Extra:      make([]byte, 32),
+				BaseFee:    big.NewInt(10000000000),
+			},
+		},
+		{
+			"receipt-for-storage",
+			&ReceiptForStorage{
+				Status:            ReceiptStatusSuccessful,
+				CumulativeGasUsed: 0x888888888,
+				Logs:              make([]*Log, 0),
+			},
+		},
+		{
+			"receipt-full",
+			&Receipt{
+				Status:            ReceiptStatusSuccessful,
+				CumulativeGasUsed: 0x888888888,
+				Logs:              make([]*Log, 0),
+			},
+		},
+		{
+			"legacy-transaction",
+			MustSignNewTx(key, signer,
+				&LegacyTx{
+					Nonce:    1,
+					GasPrice: big.NewInt(500),
+					Gas:      1000000,
+					To:       &to,
+					Value:    big.NewInt(1),
+				}),
+		},
+		{
+			"access-transaction",
+			MustSignNewTx(key, signer,
+				&AccessListTx{
+					Nonce:    1,
+					GasPrice: big.NewInt(500),
+					Gas:      1000000,
+					To:       &to,
+					Value:    big.NewInt(1),
+				}),
+		},
+		{
+			"1559-transaction",
+			MustSignNewTx(key, signer,
+				&DynamicFeeTx{
+					Nonce:     1,
+					Gas:       1000000,
+					To:        &to,
+					Value:     big.NewInt(1),
+					GasTipCap: big.NewInt(500),
+					GasFeeCap: big.NewInt(500),
+				}),
+		},
+	} {
+		if encode {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				var null = &devnull{}
+				for i := 0; i < b.N; i++ {
+					rlp.Encode(null, tc.obj)
+				}
+				b.SetBytes(int64(null.len / b.N))
+			})
+		} else {
+			data, _ := rlp.EncodeToBytes(tc.obj)
+			// Test decoding
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					if err := rlp.DecodeBytes(data, tc.obj); err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.SetBytes(int64(len(data)))
+			})
+		}
+	}
+}

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -60,7 +60,7 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 // as argument:
 // CALLDATACOPY (stack position 2)
 // CODECOPY (stack position 2)
-// EXTCODECOPY (stack poition 3)
+// EXTCODECOPY (stack position 3)
 // RETURNDATACOPY (stack position 2)
 func memoryCopierGas(stackpos int) gasFunc {
 	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -1979,20 +1979,20 @@ func TestDualHeapEviction(t *testing.T) {
 	}
 
 	add := func(urgent bool) {
-		txs := make([]*types.Transaction, 20)
-		for i := range txs {
-			// Create a test accounts and fund it
+		for i := 0; i < 20; i++ {
+			var tx *types.Transaction
+			// Create a test account and fund it
 			key, _ := crypto.GenerateKey()
 			testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1000000000000))
 			if urgent {
-				txs[i] = dynamicFeeTx(0, 100000, big.NewInt(int64(baseFee+1+i)), big.NewInt(int64(1+i)), key)
-				highTip = txs[i]
+				tx = dynamicFeeTx(0, 100000, big.NewInt(int64(baseFee+1+i)), big.NewInt(int64(1+i)), key)
+				highTip = tx
 			} else {
-				txs[i] = dynamicFeeTx(0, 100000, big.NewInt(int64(baseFee+200+i)), big.NewInt(1), key)
-				highCap = txs[i]
+				tx = dynamicFeeTx(0, 100000, big.NewInt(int64(baseFee+200+i)), big.NewInt(1), key)
+				highCap = tx
 			}
+			pool.AddRemotesSync([]*types.Transaction{tx})
 		}
-		pool.AddRemotes(txs)
 		pending, queued := pool.Stats()
 		if pending+queued != 20 {
 			t.Fatalf("transaction count mismatch: have %d, want %d", pending+queued, 10)

--- a/node/config.go
+++ b/node/config.go
@@ -92,6 +92,7 @@ type Config struct {
 	InsecureUnlockAllowed bool `toml:",omitempty"`
 
 	// NoUSB disables hardware wallet monitoring and connectivity.
+	// Deprecated: USB monitoring is disabled by default and must be enabled explicitly.
 	NoUSB bool `toml:",omitempty"`
 
 	// USB enables hardware wallet monitoring and connectivity.


### PR DESCRIPTION
Please check if what you want to add to `go-u2u` list meets [Contribution guidelines](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/unicornultrafoundation/go-u2u/blob/master/CONTRIBUTING.md#quality-standard).

### Description

- [X] Add a txpool reorg change-counter: `txpool/throttle`, `txpool/reorgtime` and `txpool/dropbetweenreorg`, to prevent too much from happening inside the pool before the pool has had a chance to run a reorg, which 'balances' the queued and pending transactions.
- [X] Add benchmarks for RLP encoding/decoding
- [X] Nitpick: Add comment about `--nousb` being deprecated
- [X] Nitpick: Fix typo in comment in `core/vm/gas_table.go`