### PR TITLE
Migration to LRU Cache for SFC

### DIFF
--- a/evmcore/state_transition.go
+++ b/evmcore/state_transition.go
@@ -18,6 +18,7 @@ package evmcore
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -343,13 +344,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		if metrics.EnabledExpensive {
 			totalEvmExecutionElapsed = time.Since(start)
 		}
-		if _, ok := st.evm.SfcPrecompile(st.to()); ok && st.sfcState != nil && vmerr == nil {
+		if _, ok := st.evm.SfcPrecompile(st.to()); ok && st.sfcState != nil && !errors.Is(vmerr, vm.ErrOutOfGas) {
 			start = time.Now()
 			sfcRet, _, sfcErr := st.evm.CallSFC(sender, st.to(), st.data, originalGas, originalValue)
 			if sfcErr != nil {
 				log.Error("TransitionDb: CallSFC failed", "sfcErr", sfcErr, "ret", common.Bytes2Hex(ret))
 			}
-			if bytes.Compare(ret, sfcRet) != 0 {
+			if !bytes.Equal(ret, sfcRet) {
 				log.Error("TransitionDb: CallSFC result different from EVM",
 					"ret", common.Bytes2Hex(ret), "sfcRet", common.Bytes2Hex(sfcRet))
 			}

--- a/u2u/contracts/sfc/sfc_utils.go
+++ b/u2u/contracts/sfc/sfc_utils.go
@@ -288,9 +288,9 @@ func encodeRevertReason(methodName string, reason string) ([]byte, error) {
 	cacheKey := "Error:" + errorMessage
 
 	// Check if we have this error message cached
-	if cachedData, ok := sfcCache.AbiPackCache[cacheKey]; ok {
+	if cachedValue, ok := sfcCache.AbiPackCache.Get(cacheKey); ok {
 		log.Info("SFC: Revert", "message", errorMessage)
-		return cachedData, nil
+		return cachedValue.([]byte), nil
 	}
 
 	// Prepend the error signature: bytes4(keccak256("Error(string)"))
@@ -314,7 +314,7 @@ func encodeRevertReason(methodName string, reason string) ([]byte, error) {
 	result = append(result, packedReason...)
 
 	// Cache the result
-	sfcCache.AbiPackCache[cacheKey] = result
+	sfcCache.AbiPackCache.Add(cacheKey, result)
 	log.Info("SFC: Revert", "message", errorMessage)
 	return result, nil
 }


### PR DESCRIPTION
This pull request refactors the caching mechanism in the `u2u/contracts/sfc/cache.go` file and related code to use an LRU (Least Recently Used) cache implementation from the `github.com/hashicorp/golang-lru` library instead of Go's built-in maps. This change provides automatic cache eviction and more efficient memory usage, especially for long-running processes. The update also introduces configurable cache sizes and adds helper functions for cache initialization and clearing.

Key changes include:

**Migration to LRU Cache:**
- Replaced all map-based caches in `HashCache`, `SlotCache`, and `SFCCache` with LRU caches, updating all relevant methods to use LRU's `Get` and `Add` methods instead of map access. [[1]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aR9-R26) [[2]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL31-R43) [[3]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL56-R84) [[4]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL88-R146) [[5]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL140-R184) [[6]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL157-R215) [[7]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL181-R225) [[8]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL201-R244) [[9]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL212-R256) [[10]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL232-R275) [[11]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL261-R305) [[12]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL280-R323) [[13]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL291-R335) [[14]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL311-R354) [[15]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL322-R366) [[16]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL341-R384) [[17]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL355-R399) [[18]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL382-R425) [[19]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL393-R437) [[20]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL413-R456) [[21]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL444-R488) [[22]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL470-R513) [[23]](diffhunk://#diff-9277c7eaa5a14ef9ca6f5bb6cffdf3b7e67d69cf2cc009834354a46c1ad8251dL291-R293) [[24]](diffhunk://#diff-9277c7eaa5a14ef9ca6f5bb6cffdf3b7e67d69cf2cc009834354a46c1ad8251dL317-R317)

**Cache Initialization and Configuration:**
- Added default cache size constants and new constructors (`NewSFCCacheWithCapacities`) to allow for custom cache sizing. The default constructor now delegates to this new function.

**Cache Clearing Improvements:**
- Updated the `ClearCache` function to purge all LRU caches in place, rather than reinitializing the `sfcCache` object.

These changes improve cache management, prevent unbounded memory growth, and make the caching layer more robust and maintainable.