### PR TITLE
Implement constants manager lru cache

### DIFF
--- a/evmcore/state_transition.go
+++ b/evmcore/state_transition.go
@@ -18,6 +18,7 @@ package evmcore
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -343,13 +344,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		if metrics.EnabledExpensive {
 			totalEvmExecutionElapsed = time.Since(start)
 		}
-		if _, ok := st.evm.SfcPrecompile(st.to()); ok && st.sfcState != nil && vmerr == nil {
+		if _, ok := st.evm.SfcPrecompile(st.to()); ok && st.sfcState != nil && !errors.Is(vmerr, vm.ErrOutOfGas) {
 			start = time.Now()
 			sfcRet, _, sfcErr := st.evm.CallSFC(sender, st.to(), st.data, originalGas, originalValue)
 			if sfcErr != nil {
 				log.Error("TransitionDb: CallSFC failed", "sfcErr", sfcErr, "ret", common.Bytes2Hex(ret))
 			}
-			if bytes.Compare(ret, sfcRet) != 0 {
+			if !bytes.Equal(ret, sfcRet) {
 				log.Error("TransitionDb: CallSFC result different from EVM",
 					"ret", common.Bytes2Hex(ret), "sfcRet", common.Bytes2Hex(sfcRet))
 			}

--- a/u2u/contracts/constant_manager/cm_cache.go
+++ b/u2u/contracts/constant_manager/cm_cache.go
@@ -3,35 +3,134 @@ package constant_manager
 import (
 	"math/big"
 	"sync"
+	"time"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/unicornultrafoundation/go-u2u/common"
 	"github.com/unicornultrafoundation/go-u2u/core/vm"
 	"github.com/unicornultrafoundation/go-u2u/log"
 )
 
+// CachedValue represents a cached constant value with validation info
+type CachedValue struct {
+	Value       *big.Int
+	StateRoot   common.Hash
+	BlockNumber *big.Int
+	Timestamp   time.Time
+}
+
 // CMCache stores cached values from the ConstantManager contract
 type CMCache struct {
-	// Public variables stored in a map for convenience
-	Values map[string]*big.Int
+	// LRU cache for values with automatic eviction
+	cache *lru.Cache
+	
 	// Owner address stored separately since it's not a big.Int
 	Owner common.Address
 
+	// State validation for cache consistency
+	StateRoot   common.Hash
+	BlockNumber *big.Int
+	
+	// Batched state root checking optimization
+	cachedStorageRoot common.Hash
+	storageRootValid  bool
+	
 	// Mutex for thread safety
 	mutex sync.RWMutex
+
+	// Cache metadata
+	LastInvalidated time.Time
 
 	// Invalidate cache signal
 	NeedInvalidating bool
 }
 
+// Cache configuration constants
+const (
+	DefaultCacheSize = 50  // Small cache since CM constants rarely change
+	MaxCacheAge      = 30 * time.Second // Auto-invalidate after 30 seconds
+)
+
 // Package-level cache instance
-var cmCache = &CMCache{
-	Values:           make(map[string]*big.Int),
-	NeedInvalidating: true,
+var cmCache *CMCache
+
+// init initializes the global CM cache
+func init() {
+	cache, err := lru.New(DefaultCacheSize)
+	if err != nil {
+		log.Error("Failed to create ConstantManager LRU cache", "err", err)
+		panic(err)
+	}
+	
+	cmCache = &CMCache{
+		cache:            cache,
+		NeedInvalidating: true,
+		LastInvalidated:  time.Now(),
+	}
 }
 
 // GetCMCache returns the ConstantManager cache instance
 func GetCMCache() *CMCache {
 	return cmCache
+}
+
+// getStorageRootCached returns the storage root, using cached value if available
+func (c *CMCache) getStorageRootCached(evm *vm.EVM) common.Hash {
+	if c.storageRootValid {
+		return c.cachedStorageRoot
+	}
+	
+	if evm != nil && evm.SfcStateDB != nil {
+		c.cachedStorageRoot = evm.SfcStateDB.GetStorageRoot(ContractAddress)
+		c.storageRootValid = true
+		return c.cachedStorageRoot
+	}
+	
+	return common.Hash{}
+}
+
+// IsStale checks if the cache is stale based on state root or time
+func (c *CMCache) IsStale(evm *vm.EVM) bool {
+	// Quick check without lock first
+	if c.NeedInvalidating {
+		return true
+	}
+	
+	// Check cache age without lock
+	if time.Since(c.LastInvalidated) > MaxCacheAge {
+		return true
+	}
+	
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	
+	// Check state root mismatch using batched storage root
+	if evm != nil && evm.SfcStateDB != nil {
+		currentStateRoot := c.getStorageRootCached(evm)
+		if c.StateRoot != currentStateRoot {
+			return true
+		}
+		
+		// Check block number mismatch
+		currentBlockNumber := evm.Context.BlockNumber
+		if c.BlockNumber == nil || c.BlockNumber.Cmp(currentBlockNumber) != 0 {
+			return true
+		}
+	}
+	
+	return false
+}
+
+// GetValueSafe returns a cached value with lazy loading and validation
+func (c *CMCache) GetValueSafe(evm *vm.EVM, key string) *big.Int {
+	// Check if cache needs refresh
+	if c.IsStale(evm) {
+		log.Debug("ConstantManager cache is stale, refreshing", "key", key)
+		InvalidateCmCache(evm)
+	}
+	
+	// No need for per-value validation since IsStale() already validated
+	return c.GetValue(key)
 }
 
 // InvalidateCmCache invalidates the cache with the correct values from CM contract.
@@ -40,107 +139,106 @@ func InvalidateCmCache(evm *vm.EVM) {
 	cmCache.mutex.Lock()
 	defer cmCache.mutex.Unlock()
 
-	// Initialize the map if it doesn't exist
-	if cmCache.Values == nil {
-		cmCache.Values = make(map[string]*big.Int)
+	var currentStateRoot common.Hash
+	var currentBlockNumber *big.Int
+	
+	if evm != nil && evm.SfcStateDB != nil {
+		currentStateRoot = cmCache.getStorageRootCached(evm)
+		currentBlockNumber = new(big.Int).Set(evm.Context.BlockNumber)
+	}
+	
+	now := time.Now()
+
+	// Helper function to load and cache a value
+	loadValue := func(key string, slot int64) {
+		val := evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(slot)))
+		cachedVal := &CachedValue{
+			Value:       val.Big(),
+			StateRoot:   currentStateRoot,
+			BlockNumber: currentBlockNumber,
+			Timestamp:   now,
+		}
+		cmCache.cache.Add(key, cachedVal)
 	}
 
-	// Initialize all cache values
-	val := evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(minSelfStakeSlot)))
-	cmCache.Values[MinSelfStakeKey] = val.Big()
+	// Load all constant values into LRU cache
+	loadValue(MinSelfStakeKey, minSelfStakeSlot)
+	loadValue(MaxDelegatedRatioKey, maxDelegatedRatioSlot)
+	loadValue(ValidatorCommissionKey, validatorCommissionSlot)
+	loadValue(BurntFeeShareKey, burntFeeShareSlot)
+	loadValue(TreasuryFeeShareKey, treasuryFeeShareSlot)
+	loadValue(UnlockedRewardRatioKey, unlockedRewardRatioSlot)
+	loadValue(MinLockupDurationKey, minLockupDurationSlot)
+	loadValue(MaxLockupDurationKey, maxLockupDurationSlot)
+	loadValue(WithdrawalPeriodEpochsKey, withdrawalPeriodEpochsSlot)
+	loadValue(WithdrawalPeriodTimeKey, withdrawalPeriodTimeSlot)
+	loadValue(BaseRewardPerSecondKey, baseRewardPerSecondSlot)
+	loadValue(OfflinePenaltyThresholdBlocksNumKey, offlinePenaltyThresholdBlocksNumSlot)
+	loadValue(OfflinePenaltyThresholdTimeKey, offlinePenaltyThresholdTimeSlot)
+	loadValue(TargetGasPowerPerSecondKey, targetGasPowerPerSecondSlot)
+	loadValue(GasPriceBalancingCounterweightKey, gasPriceBalancingCounterweightSlot)
 
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(maxDelegatedRatioSlot)))
-	cmCache.Values[MaxDelegatedRatioKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(validatorCommissionSlot)))
-	cmCache.Values[ValidatorCommissionKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(burntFeeShareSlot)))
-	cmCache.Values[BurntFeeShareKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(treasuryFeeShareSlot)))
-	cmCache.Values[TreasuryFeeShareKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(unlockedRewardRatioSlot)))
-	cmCache.Values[UnlockedRewardRatioKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(minLockupDurationSlot)))
-	cmCache.Values[MinLockupDurationKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(maxLockupDurationSlot)))
-	cmCache.Values[MaxLockupDurationKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(withdrawalPeriodEpochsSlot)))
-	cmCache.Values[WithdrawalPeriodEpochsKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(withdrawalPeriodTimeSlot)))
-	cmCache.Values[WithdrawalPeriodTimeKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(baseRewardPerSecondSlot)))
-	cmCache.Values[BaseRewardPerSecondKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(offlinePenaltyThresholdBlocksNumSlot)))
-	cmCache.Values[OfflinePenaltyThresholdBlocksNumKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(offlinePenaltyThresholdTimeSlot)))
-	cmCache.Values[OfflinePenaltyThresholdTimeKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(targetGasPowerPerSecondSlot)))
-	cmCache.Values[TargetGasPowerPerSecondKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(gasPriceBalancingCounterweightSlot)))
-	cmCache.Values[GasPriceBalancingCounterweightKey] = val.Big()
-
-	val = evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(ownerSlot)))
+	// Load owner separately
+	val := evm.SfcStateDB.GetState(ContractAddress, common.BigToHash(big.NewInt(ownerSlot)))
 	cmCache.Owner = common.BytesToAddress(val.Bytes())
 
+	// Update cache metadata
+	cmCache.StateRoot = currentStateRoot
+	cmCache.BlockNumber = currentBlockNumber
+	cmCache.LastInvalidated = now
 	cmCache.NeedInvalidating = false
+	
+	// Reset batched storage root cache
+	cmCache.storageRootValid = false
+	
 	log.Info("ConstantsManager cache invalidated successfully")
 }
 
-// UpdateCacheValue updates a specific value in the cache
+// UpdateCacheValue updates a specific value in the cache and marks it for invalidation
 func UpdateCacheValue(slot int64, value *big.Int) {
 	cmCache.mutex.Lock()
 	defer cmCache.mutex.Unlock()
 
-	// Initialize the map if it doesn't exist
-	if cmCache.Values == nil {
-		cmCache.Values = make(map[string]*big.Int)
-	}
-
+	var key string
 	switch slot {
 	case minSelfStakeSlot:
-		cmCache.Values[MinSelfStakeKey] = new(big.Int).Set(value)
+		key = MinSelfStakeKey
 	case maxDelegatedRatioSlot:
-		cmCache.Values[MaxDelegatedRatioKey] = new(big.Int).Set(value)
+		key = MaxDelegatedRatioKey
 	case validatorCommissionSlot:
-		cmCache.Values[ValidatorCommissionKey] = new(big.Int).Set(value)
+		key = ValidatorCommissionKey
 	case burntFeeShareSlot:
-		cmCache.Values[BurntFeeShareKey] = new(big.Int).Set(value)
+		key = BurntFeeShareKey
 	case treasuryFeeShareSlot:
-		cmCache.Values[TreasuryFeeShareKey] = new(big.Int).Set(value)
+		key = TreasuryFeeShareKey
 	case unlockedRewardRatioSlot:
-		cmCache.Values[UnlockedRewardRatioKey] = new(big.Int).Set(value)
+		key = UnlockedRewardRatioKey
 	case minLockupDurationSlot:
-		cmCache.Values[MinLockupDurationKey] = new(big.Int).Set(value)
+		key = MinLockupDurationKey
 	case maxLockupDurationSlot:
-		cmCache.Values[MaxLockupDurationKey] = new(big.Int).Set(value)
+		key = MaxLockupDurationKey
 	case withdrawalPeriodEpochsSlot:
-		cmCache.Values[WithdrawalPeriodEpochsKey] = new(big.Int).Set(value)
+		key = WithdrawalPeriodEpochsKey
 	case withdrawalPeriodTimeSlot:
-		cmCache.Values[WithdrawalPeriodTimeKey] = new(big.Int).Set(value)
+		key = WithdrawalPeriodTimeKey
 	case baseRewardPerSecondSlot:
-		cmCache.Values[BaseRewardPerSecondKey] = new(big.Int).Set(value)
+		key = BaseRewardPerSecondKey
 	case offlinePenaltyThresholdBlocksNumSlot:
-		cmCache.Values[OfflinePenaltyThresholdBlocksNumKey] = new(big.Int).Set(value)
+		key = OfflinePenaltyThresholdBlocksNumKey
 	case offlinePenaltyThresholdTimeSlot:
-		cmCache.Values[OfflinePenaltyThresholdTimeKey] = new(big.Int).Set(value)
+		key = OfflinePenaltyThresholdTimeKey
 	case targetGasPowerPerSecondSlot:
-		cmCache.Values[TargetGasPowerPerSecondKey] = new(big.Int).Set(value)
+		key = TargetGasPowerPerSecondKey
 	case gasPriceBalancingCounterweightSlot:
-		cmCache.Values[GasPriceBalancingCounterweightKey] = new(big.Int).Set(value)
+		key = GasPriceBalancingCounterweightKey
+	default:
+		return
 	}
 
+	// Remove the specific key from cache since it's now stale
+	cmCache.cache.Remove(key)
+	
+	// Mark cache as needing full invalidation
 	cmCache.NeedInvalidating = true
 }
 
@@ -152,21 +250,32 @@ func UpdateOwner(owner common.Address) {
 	cmCache.Owner = owner
 }
 
+// InvalidateCMCacheFlag marks the ConstantManager cache as needing invalidation
+func InvalidateCMCacheFlag() {
+	cmCache.mutex.Lock()
+	defer cmCache.mutex.Unlock()
+	
+	cmCache.NeedInvalidating = true
+}
+
 // Getter functions for cached values
 
-// GetValue returns a cached value by key
+// GetValue returns a cached value by key (legacy method, prefer GetValueSafe)
 func (c *CMCache) GetValue(key string) *big.Int {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
-	value, exists := c.Values[key]
-	if !exists || value == nil {
-		log.Warn("ConstantsManager cache is nil", "key", key)
-		return big.NewInt(0)
+	// Try to get from LRU cache
+	if val, found := c.cache.Get(key); found {
+		if cachedVal, ok := val.(*CachedValue); ok {
+			return new(big.Int).Set(cachedVal.Value)
+		}
 	}
 
-	return new(big.Int).Set(value)
+	log.Warn("ConstantsManager cache miss (legacy method)", "key", key)
+	return big.NewInt(0)
 }
+
 
 // GetOwner returns the cached owner of the contract
 func (c *CMCache) GetOwner() common.Address {

--- a/u2u/contracts/constant_manager/constant_manager_precompiled.go
+++ b/u2u/contracts/constant_manager/constant_manager_precompiled.go
@@ -63,8 +63,8 @@ type ConstantManagerPrecompile struct{}
 
 // Run runs the precompiled contract
 func (c *ConstantManagerPrecompile) Run(evm *vm.EVM, caller common.Address, input []byte, suppliedGas uint64, value *big.Int) ([]byte, uint64, error) {
-	// Initialize/Invalidate the cache
-	if cmCache.NeedInvalidating || cmCache.Values == nil || len(cmCache.Values) == 0 {
+	// Initialize/Invalidate the cache if needed
+	if cmCache.IsStale(evm) {
 		InvalidateCmCache(evm)
 	}
 	// Parse the input to get method and arguments

--- a/u2u/contracts/sfc/sfc_seal_epoch.go
+++ b/u2u/contracts/sfc/sfc_seal_epoch.go
@@ -155,8 +155,8 @@ func handleSealEpoch(evm *vm.EVM, caller common.Address, args []interface{}) ([]
 	PutBigInt(endTimeOffsetBig)
 	PutBigInt(endTimeSlot)
 
-	// Get the base reward per second from the constants manager
-	baseRewardPerSecond := getConstantsManagerVariable("baseRewardPerSecond")
+	// Get the base reward per second from the constants manager using safe validation
+	baseRewardPerSecond := getConstantsManagerVariableSafe(evm, "baseRewardPerSecond")
 
 	// Update epoch snapshot base reward per second (snapshot.baseRewardPerSecond = c.baseRewardPerSecond() in Solidity)
 	baseRewardPerSecondOffsetBig := GetBigInt().SetInt64(baseRewardPerSecondOffset)
@@ -835,8 +835,8 @@ func handleInternalSealEpochMinGasPrice(evm *vm.EVM, epochDuration *big.Int, epo
 	// Initialize gas used
 	var gasUsed uint64 = 0
 
-	// Get the target gas power per second from the constants manager
-	targetGasPowerPerSecond := getConstantsManagerVariable("targetGasPowerPerSecond")
+	// Get the target gas power per second from the constants manager using safe validation
+	targetGasPowerPerSecond := getConstantsManagerVariableSafe(evm, "targetGasPowerPerSecond")
 
 	// Calculate target epoch gas
 	targetEpochGas := new(big.Int).Mul(epochDuration, targetGasPowerPerSecond)
@@ -850,7 +850,7 @@ func handleInternalSealEpochMinGasPrice(evm *vm.EVM, epochDuration *big.Int, epo
 	gasPriceDeltaRatio.Div(gasPriceDeltaRatio, targetEpochGas)
 
 	// Get the gas price balancing counterweight from the constants manager
-	counterweight := getConstantsManagerVariable("gasPriceBalancingCounterweight")
+	counterweight := getConstantsManagerVariableSafe(evm, "gasPriceBalancingCounterweight")
 
 	// Scale down the change speed
 	// gasPriceDeltaRatio = (epochDuration * gasPriceDeltaRatio + counterweight * Decimal.unit()) / (epochDuration + counterweight)

--- a/u2u/contracts/sfc/sfc_utils.go
+++ b/u2u/contracts/sfc/sfc_utils.go
@@ -925,6 +925,11 @@ func getConstantsManagerVariable(methodName string) *big.Int {
 	return constant_manager.GetCMCache().GetValue(methodName)
 }
 
+// getConstantsManagerVariableSafe returns a constant value with EVM context validation
+func getConstantsManagerVariableSafe(evm *vm.EVM, methodName string) *big.Int {
+	return constant_manager.GetCMCache().GetValueSafe(evm, methodName)
+}
+
 // getCurrentEpoch returns the current epoch value (currentSealedEpoch + 1)
 // This implements the logic from the currentEpoch() function in SFCBase.sol
 func getCurrentEpoch(evm *vm.EVM) (*big.Int, uint64, error) {

--- a/u2u/contracts/sfc/sfc_utils.go
+++ b/u2u/contracts/sfc/sfc_utils.go
@@ -288,9 +288,9 @@ func encodeRevertReason(methodName string, reason string) ([]byte, error) {
 	cacheKey := "Error:" + errorMessage
 
 	// Check if we have this error message cached
-	if cachedData, ok := sfcCache.AbiPackCache[cacheKey]; ok {
+	if cachedValue, ok := sfcCache.AbiPackCache.Get(cacheKey); ok {
 		log.Info("SFC: Revert", "message", errorMessage)
-		return cachedData, nil
+		return cachedValue.([]byte), nil
 	}
 
 	// Prepend the error signature: bytes4(keccak256("Error(string)"))
@@ -314,7 +314,7 @@ func encodeRevertReason(methodName string, reason string) ([]byte, error) {
 	result = append(result, packedReason...)
 
 	// Cache the result
-	sfcCache.AbiPackCache[cacheKey] = result
+	sfcCache.AbiPackCache.Add(cacheKey, result)
 	log.Info("SFC: Revert", "message", errorMessage)
 	return result, nil
 }


### PR DESCRIPTION
This pull request introduces significant improvements to caching mechanisms in both the ConstantManager and SFC contract modules. The main goals are to improve cache consistency, enable automatic eviction of stale data, and optimize memory usage by replacing map-based caches with LRU (Least Recently Used) caches. The changes also add better cache invalidation logic and time-based staleness checks.

**ConstantManager cache improvements:**

- Switched from a map-based cache to an LRU cache for storing constant values, with a new `CachedValue` struct that tracks additional metadata (state root, block number, timestamp). Added time-based and state-root-based staleness checks to ensure cache consistency.
- Refactored cache invalidation logic: cache is now invalidated automatically if it becomes stale (by time, state root, or block number), and a new `InvalidateCMCacheFlag` method allows marking the cache as needing invalidation. [[1]](diffhunk://#diff-7e8144ade1d7dcec295fb84d10930abf8e0bcbaff223f8fea5791a7ffa49870eR6-R241) [[2]](diffhunk://#diff-7e8144ade1d7dcec295fb84d10930abf8e0bcbaff223f8fea5791a7ffa49870eR253-R279)
- Updated `GetValue` and related methods to use the new LRU cache structure, and added a safe accessor (`GetValueSafe`) that validates staleness before returning a value. [[1]](diffhunk://#diff-7e8144ade1d7dcec295fb84d10930abf8e0bcbaff223f8fea5791a7ffa49870eR6-R241) [[2]](diffhunk://#diff-7e8144ade1d7dcec295fb84d10930abf8e0bcbaff223f8fea5791a7ffa49870eR253-R279)
- Updated the `ConstantManagerPrecompile` contract to use the new staleness logic for cache initialization.

**SFC contract cache improvements:**

- Replaced all map-based caches in `HashCache`, `SlotCache`, and `SFCCache` with LRU caches, adding configurable cache capacities and automatic eviction for better memory control. [[1]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aR9-R26) [[2]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL56-R84) [[3]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL88-R146)
- Refactored cache access patterns throughout SFC cache code to use LRU cache methods (`Get`, `Add`, `Purge`) instead of direct map access, ensuring consistency and improved performance. [[1]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL31-R43) [[2]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL140-R184) [[3]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL157-R215) [[4]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL181-R225) [[5]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL201-R244) [[6]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL212-R256)
- Improved cache clearing logic to properly purge all LRU caches instead of reinitializing map-based caches.

**Miscellaneous improvements:**

- Minor bug fix: replaced deprecated usage of `bytes.Compare` with `bytes.Equal` for comparing byte slices in EVM state transition logic.
- Added missing import of the `errors` package for improved error handling.

These changes make the caching infrastructure more robust, scalable, and easier to maintain, reducing potential issues with stale or inconsistent data.

**References:**  
[[1]](diffhunk://#diff-7e8144ade1d7dcec295fb84d10930abf8e0bcbaff223f8fea5791a7ffa49870eR6-R241) [[2]](diffhunk://#diff-7e8144ade1d7dcec295fb84d10930abf8e0bcbaff223f8fea5791a7ffa49870eR253-R279) [[3]](diffhunk://#diff-9cfb690e2f89440c501387249ca93899883726d4728beb644c361bfcfbe40b9fL66-R67) [[4]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aR9-R26) [[5]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL56-R84) [[6]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL88-R146) [[7]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL31-R43) [[8]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL140-R184) [[9]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL157-R215) [[10]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL181-R225) [[11]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL201-R244) [[12]](diffhunk://#diff-cf6d6cfb7720221cfad789e2e109fe8339ffbd667b1425019cc5348d37c8ae0aL212-R256) [[13]](diffhunk://#diff-97778d931db41198de6231c140232567a2310a9c11e454a8eafb240e45b707c2L346-R353) [[14]](diffhunk://#diff-97778d931db41198de6231c140232567a2310a9c11e454a8eafb240e45b707c2R21)